### PR TITLE
chore: add .kotlin, docs, and memory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,10 @@ fabric.properties
 
 # Git worktrees
 .worktrees/
+
+# Kotlin compiler generated files
+.kotlin/
+
+# Claude Code local files
+docs/
+memory/


### PR DESCRIPTION
## Summary
- Ignores `.kotlin/` — Kotlin compiler-generated cache and error logs
- Ignores `docs/` — Claude Code Superpowers local plan files
- Ignores `memory/` — Claude Code auto-memory directory for this project

These were showing up as untracked files but should never be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)