### PR TITLE
fix(deps): force safe versions of vulnerable build classpath deps

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,19 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.report.ReportMergeTask
 
+buildscript {
+    configurations.classpath {
+        resolutionStrategy {
+            force(
+                "org.bouncycastle:bcpkix-jdk18on:1.84",
+                "org.bouncycastle:bcutil-jdk18on:1.84",
+                "org.bitbucket.b_c:jose4j:0.9.6",
+                "org.jdom:jdom2:2.0.6.1"
+            )
+        }
+    }
+}
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {


### PR DESCRIPTION
## Summary

- Forces `org.bouncycastle:bcpkix-jdk18on` 1.79 → **1.84** (Medium: broken/risky crypto algorithm)
- Forces `org.bitbucket.b_c:jose4j` 0.9.5 → **0.9.6** (High: DoS via compressed JWE content)
- Forces `org.jdom:jdom2` 2.0.6 → **2.0.6.1** (High: XXE injection via Jetifier)

All three are transitive build-time dependencies pulled in by AGP/Jetifier tooling — they are **not shipped in the app binary**. The fix uses `buildscript.configurations.classpath.resolutionStrategy.force(...)` to pin patched versions.

Closes Dependabot alerts #59, #61, #64.

## Test plan

- [x] `./gradlew buildEnvironment` confirms all three packages resolve to patched versions
- [x] `./gradlew assembleProdDebug` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)