### PR TITLE
fix(ci): move write permissions to job level

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,9 +4,6 @@ name: CI
     branches:
       - master
   pull_request:
-permissions:
-  contents: write
-  security-events: write
 env:
   GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -14,6 +11,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Removes top-level `permissions` block that was granting `contents: write` and `security-events: write` to **all** jobs
- Adds `permissions: contents: write` only to the `build` job, which is the sole job that requires it (for `dependency-graph: generate-and-submit` via `gradle/actions/setup-gradle`)
- Drops `security-events: write` entirely — no job in this workflow uploads SARIF or security events

Fixes code scanning alerts #1 and #2 (`githubactions:S8233`: "Write permissions should be defined at the job level").

## Test plan

- [x] `build` job retains `contents: write` for dependency graph submission
- [x] All other jobs (`lint`, `detekt`, `test`, `sonar`, `android-test`) run with default read-only permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)