### PR TITLE
feat(core:network): add Koin module

### DIFF
--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -16,4 +16,6 @@ dependencies {
     implementation(libs.firebase.firestore)
 
     testImplementation(project(":core:testing"))
+
+    implementation(libs.koin.android)
 }

--- a/core/network/src/main/java/com/toquete/boxbox/core/network/di/NetworkKoinModule.kt
+++ b/core/network/src/main/java/com/toquete/boxbox/core/network/di/NetworkKoinModule.kt
@@ -1,0 +1,53 @@
+package com.toquete.boxbox.core.network.di
+
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.firestore
+import com.toquete.boxbox.core.network.BoxBoxRemoteDatabase
+import com.toquete.boxbox.core.network.BoxBoxService
+import com.toquete.boxbox.core.network.firebase.FirebaseDatabase
+import com.toquete.boxbox.core.network.interceptor.HttpLogger
+import com.toquete.boxbox.core.network.interceptor.NetworkErrorInterceptor
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import org.koin.dsl.module
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+
+private const val BASE_URL = "https://api.jolpi.ca/ergast/f1/"
+private const val JSON_MEDIA_TYPE = "application/json"
+
+val networkModule = module {
+    single<Json> {
+        Json {
+            ignoreUnknownKeys = true
+            explicitNulls = false
+        }
+    }
+
+    single<OkHttpClient> {
+        val logging = HttpLoggingInterceptor(HttpLogger()).apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+        OkHttpClient.Builder()
+            .addInterceptor(logging)
+            .addInterceptor(NetworkErrorInterceptor())
+            .build()
+    }
+
+    single<Retrofit> {
+        Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .addConverterFactory(get<Json>().asConverterFactory(JSON_MEDIA_TYPE.toMediaType()))
+            .client(get())
+            .build()
+    }
+
+    single<BoxBoxService> { get<Retrofit>().create(BoxBoxService::class.java) }
+
+    single<FirebaseFirestore> { Firebase.firestore }
+
+    single<BoxBoxRemoteDatabase> { FirebaseDatabase(get()) }
+}

--- a/core/network/src/main/java/com/toquete/boxbox/core/network/di/NetworkKoinModule.kt
+++ b/core/network/src/main/java/com/toquete/boxbox/core/network/di/NetworkKoinModule.kt
@@ -12,6 +12,8 @@ import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
@@ -49,5 +51,5 @@ val networkModule = module {
 
     single<FirebaseFirestore> { Firebase.firestore }
 
-    single<BoxBoxRemoteDatabase> { FirebaseDatabase(get()) }
+    singleOf(::FirebaseDatabase) bind BoxBoxRemoteDatabase::class
 }


### PR DESCRIPTION
## Summary
- Adds `networkModule` Koin module providing `Json`, `OkHttpClient`, `Retrofit`, `BoxBoxService`, `FirebaseFirestore`, `BoxBoxRemoteDatabase`
- Adds `koin-android` dependency to `build.gradle.kts`
- No existing Hilt code removed — Hilt and Koin coexist until the full Hilt removal PR

## Part of
Phase A (Hilt → Koin) — Task A1.2