### PR TITLE
feat(core:preferences): add Koin module

### DIFF
--- a/core/preferences/build.gradle.kts
+++ b/core/preferences/build.gradle.kts
@@ -12,4 +12,6 @@ dependencies {
     implementation(libs.datastore.preferences)
 
     testImplementation(project(":core:testing"))
+
+    implementation(libs.koin.android)
 }

--- a/core/preferences/src/main/java/com/toquete/boxbox/core/preferences/di/PreferencesKoinModule.kt
+++ b/core/preferences/src/main/java/com/toquete/boxbox/core/preferences/di/PreferencesKoinModule.kt
@@ -5,6 +5,8 @@ import androidx.datastore.preferences.preferencesDataStoreFile
 import com.toquete.boxbox.core.preferences.repository.DataStoreUserPreferencesRepository
 import com.toquete.boxbox.domain.repository.UserPreferencesRepository
 import org.koin.android.ext.koin.androidContext
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 private const val USER_PREFERENCES = "user_preferences"
@@ -15,5 +17,5 @@ val preferencesModule = module {
             produceFile = { androidContext().preferencesDataStoreFile(USER_PREFERENCES) }
         )
     }
-    single<UserPreferencesRepository> { DataStoreUserPreferencesRepository(get()) }
+    singleOf(::DataStoreUserPreferencesRepository) bind UserPreferencesRepository::class
 }

--- a/core/preferences/src/main/java/com/toquete/boxbox/core/preferences/di/PreferencesKoinModule.kt
+++ b/core/preferences/src/main/java/com/toquete/boxbox/core/preferences/di/PreferencesKoinModule.kt
@@ -1,0 +1,19 @@
+package com.toquete.boxbox.core.preferences.di
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.preferencesDataStoreFile
+import com.toquete.boxbox.core.preferences.repository.DataStoreUserPreferencesRepository
+import com.toquete.boxbox.domain.repository.UserPreferencesRepository
+import org.koin.android.ext.koin.androidContext
+import org.koin.dsl.module
+
+private const val USER_PREFERENCES = "user_preferences"
+
+val preferencesModule = module {
+    single {
+        PreferenceDataStoreFactory.create(
+            produceFile = { androidContext().preferencesDataStoreFile(USER_PREFERENCES) }
+        )
+    }
+    single<UserPreferencesRepository> { DataStoreUserPreferencesRepository(get()) }
+}


### PR DESCRIPTION
## Summary
- Adds `preferencesModule` Koin module providing `DataStore<Preferences>` and `UserPreferencesRepository`
- Adds `koin-android` dependency to `build.gradle.kts`
- No existing Hilt code removed — Hilt and Koin coexist until the full Hilt removal PR

## Part of
Phase A (Hilt → Koin) — Task A1.4