### PR TITLE
feat(data:driverstandings): add Koin module

### DIFF
--- a/data/driverstandings/build.gradle.kts
+++ b/data/driverstandings/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(project(":core:database"))
     implementation(project(":core:network"))
     implementation(project(":domain"))
+    implementation(libs.koin.android)
     demoImplementation(libs.serialization)
     testImplementation(project(":core:testing"))
 }

--- a/data/driverstandings/src/main/java/com/toquete/boxbox/data/driverstandings/di/DriverStandingsKoinModule.kt
+++ b/data/driverstandings/src/main/java/com/toquete/boxbox/data/driverstandings/di/DriverStandingsKoinModule.kt
@@ -1,0 +1,14 @@
+package com.toquete.boxbox.data.driverstandings.di
+
+import com.toquete.boxbox.data.driverstandings.repository.DefaultDriverStandingsRepository
+import com.toquete.boxbox.data.driverstandings.source.remote.DefaultDriverStandingsRemoteDataSource
+import com.toquete.boxbox.data.driverstandings.source.remote.DriverStandingsRemoteDataSource
+import com.toquete.boxbox.domain.repository.DriverStandingsRepository
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val driverStandingsModule = module {
+    singleOf(::DefaultDriverStandingsRemoteDataSource) bind DriverStandingsRemoteDataSource::class
+    singleOf(::DefaultDriverStandingsRepository) bind DriverStandingsRepository::class
+}


### PR DESCRIPTION
## Summary
- Adds `driverStandingsModule` Koin module providing `DriverStandingsRemoteDataSource` and `DriverStandingsRepository`
- Adds `koin-android` dependency
- No existing Hilt code removed — Hilt and Koin coexist until the full Hilt removal PR

## Part of
Phase A (Hilt → Koin) — Task A2