### PR TITLE
feat(data:constructorstandings): add Koin module

### DIFF
--- a/data/constructorstandings/build.gradle.kts
+++ b/data/constructorstandings/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(project(":core:database"))
     implementation(project(":core:network"))
     implementation(project(":domain"))
+    implementation(libs.koin.android)
     demoImplementation(libs.serialization)
     testImplementation(project(":core:testing"))
 }

--- a/data/constructorstandings/src/main/java/com/toquete/boxbox/data/constructorstandings/di/ConstructorStandingsKoinModule.kt
+++ b/data/constructorstandings/src/main/java/com/toquete/boxbox/data/constructorstandings/di/ConstructorStandingsKoinModule.kt
@@ -1,0 +1,14 @@
+package com.toquete.boxbox.data.constructorstandings.di
+
+import com.toquete.boxbox.data.constructorstandings.repository.DefaultConstructorStandingsRepository
+import com.toquete.boxbox.data.constructorstandings.source.remote.ConstructorStandingsRemoteDataSource
+import com.toquete.boxbox.data.constructorstandings.source.remote.DefaultConstructorStandingsRemoteDataSource
+import com.toquete.boxbox.domain.repository.ConstructorStandingsRepository
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val constructorStandingsModule = module {
+    singleOf(::DefaultConstructorStandingsRemoteDataSource) bind ConstructorStandingsRemoteDataSource::class
+    singleOf(::DefaultConstructorStandingsRepository) bind ConstructorStandingsRepository::class
+}


### PR DESCRIPTION
## Summary
- Adds `constructorStandingsModule` Koin module providing `ConstructorStandingsRemoteDataSource` and `ConstructorStandingsRepository`
- Adds `koin-android` dependency
- No existing Hilt code removed — Hilt and Koin coexist until the full Hilt removal PR

## Part of
Phase A (Hilt → Koin) — Task A2