### PR TITLE
feat(data:raceresults): add Koin module

### DIFF
--- a/data/raceresults/build.gradle.kts
+++ b/data/raceresults/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(project(":core:database"))
     implementation(project(":core:network"))
     implementation(project(":domain"))
+    implementation(libs.koin.android)
     demoImplementation(libs.serialization)
     testImplementation(project(":core:testing"))
 }

--- a/data/raceresults/src/main/java/com/toquete/boxbox/data/raceresults/di/RaceResultsKoinModule.kt
+++ b/data/raceresults/src/main/java/com/toquete/boxbox/data/raceresults/di/RaceResultsKoinModule.kt
@@ -1,0 +1,14 @@
+package com.toquete.boxbox.data.raceresults.di
+
+import com.toquete.boxbox.data.raceresults.repository.DefaultRaceResultRepository
+import com.toquete.boxbox.data.raceresults.source.remote.DefaultRaceResultRemoteDataSource
+import com.toquete.boxbox.data.raceresults.source.remote.RaceResultRemoteDataSource
+import com.toquete.boxbox.domain.repository.RaceResultRepository
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val raceResultsModule = module {
+    singleOf(::DefaultRaceResultRemoteDataSource) bind RaceResultRemoteDataSource::class
+    singleOf(::DefaultRaceResultRepository) bind RaceResultRepository::class
+}


### PR DESCRIPTION
## Summary
- Adds `raceResultsModule` Koin module providing `RaceResultRemoteDataSource` and `RaceResultRepository`
- Adds `koin-android` dependency
- No existing Hilt code removed — Hilt and Koin coexist until the full Hilt removal PR

## Part of
Phase A (Hilt → Koin) — Task A2