### PR TITLE
feat(data:sprintresults): add Koin module

### DIFF
--- a/data/sprintresults/build.gradle.kts
+++ b/data/sprintresults/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(project(":core:database"))
     implementation(project(":core:network"))
     implementation(project(":domain"))
+    implementation(libs.koin.android)
     demoImplementation(libs.serialization)
     testImplementation(project(":core:testing"))
 }

--- a/data/sprintresults/src/main/java/com/toquete/boxbox/data/sprintresults/di/SprintResultsKoinModule.kt
+++ b/data/sprintresults/src/main/java/com/toquete/boxbox/data/sprintresults/di/SprintResultsKoinModule.kt
@@ -1,0 +1,14 @@
+package com.toquete.boxbox.data.sprintresults.di
+
+import com.toquete.boxbox.data.sprintresults.repository.DefaultSprintResultRepository
+import com.toquete.boxbox.data.sprintresults.source.remote.DefaultSprintResultRemoteDataSource
+import com.toquete.boxbox.data.sprintresults.source.remote.SprintResultRemoteDataSource
+import com.toquete.boxbox.domain.repository.SprintResultRepository
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val sprintResultsModule = module {
+    singleOf(::DefaultSprintResultRemoteDataSource) bind SprintResultRemoteDataSource::class
+    singleOf(::DefaultSprintResultRepository) bind SprintResultRepository::class
+}


### PR DESCRIPTION
## Summary
- Adds `sprintResultsModule` Koin module providing `SprintResultRemoteDataSource` and `SprintResultRepository`
- Adds `koin-android` dependency
- No existing Hilt code removed — Hilt and Koin coexist until the full Hilt removal PR

## Part of
Phase A (Hilt → Koin) — Task A2