### PR TITLE
feat(data:countries): add Koin module

### DIFF
--- a/data/countries/build.gradle.kts
+++ b/data/countries/build.gradle.kts
@@ -11,5 +11,6 @@ dependencies {
     implementation(project(":core:database"))
     implementation(project(":core:network"))
     implementation(project(":domain"))
+    implementation(libs.koin.android)
     testImplementation(project(":core:testing"))
 }

--- a/data/countries/src/main/java/com/toquete/boxbox/data/countries/di/CountriesKoinModule.kt
+++ b/data/countries/src/main/java/com/toquete/boxbox/data/countries/di/CountriesKoinModule.kt
@@ -1,0 +1,14 @@
+package com.toquete.boxbox.data.countries.di
+
+import com.toquete.boxbox.data.countries.repository.DefaultCountryRepository
+import com.toquete.boxbox.data.countries.source.remote.CountryRemoteDataSource
+import com.toquete.boxbox.data.countries.source.remote.DefaultCountryRemoteDataSource
+import com.toquete.boxbox.domain.repository.CountryRepository
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val countriesModule = module {
+    singleOf(::DefaultCountryRemoteDataSource) bind CountryRemoteDataSource::class
+    singleOf(::DefaultCountryRepository) bind CountryRepository::class
+}


### PR DESCRIPTION
## Summary
- Adds `countriesModule` Koin module providing `CountryRemoteDataSource` and `CountryRepository`
- Adds `koin-android` dependency
- No existing Hilt code removed — Hilt and Koin coexist until the full Hilt removal PR

## Part of
Phase A (Hilt → Koin) — Task A2