### PR TITLE
feat(data:driverimages): add Koin module

### DIFF
--- a/data/driverimages/build.gradle.kts
+++ b/data/driverimages/build.gradle.kts
@@ -11,5 +11,6 @@ dependencies {
     implementation(project(":core:database"))
     implementation(project(":core:network"))
     implementation(project(":domain"))
+    implementation(libs.koin.android)
     testImplementation(project(":core:testing"))
 }

--- a/data/driverimages/src/main/java/com/toquete/boxbox/data/driverimages/di/DriverImagesKoinModule.kt
+++ b/data/driverimages/src/main/java/com/toquete/boxbox/data/driverimages/di/DriverImagesKoinModule.kt
@@ -1,0 +1,14 @@
+package com.toquete.boxbox.data.driverimages.di
+
+import com.toquete.boxbox.data.driverimages.repository.DefaultDriverImageRepository
+import com.toquete.boxbox.data.driverimages.source.remote.DefaultDriverImageRemoteDataSource
+import com.toquete.boxbox.data.driverimages.source.remote.DriverImageRemoteDataSource
+import com.toquete.boxbox.domain.repository.DriverImageRepository
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val driverImagesModule = module {
+    singleOf(::DefaultDriverImageRemoteDataSource) bind DriverImageRemoteDataSource::class
+    singleOf(::DefaultDriverImageRepository) bind DriverImageRepository::class
+}


### PR DESCRIPTION
## Summary
- Adds `driverImagesModule` Koin module providing `DriverImageRemoteDataSource` and `DriverImageRepository`
- Adds `koin-android` dependency
- No existing Hilt code removed — Hilt and Koin coexist until the full Hilt removal PR

## Part of
Phase A (Hilt → Koin) — Task A2