### PR TITLE
feat(data:constructorimages): add Koin module

### DIFF
--- a/data/constructorimages/build.gradle.kts
+++ b/data/constructorimages/build.gradle.kts
@@ -11,5 +11,6 @@ dependencies {
     implementation(project(":core:database"))
     implementation(project(":core:network"))
     implementation(project(":domain"))
+    implementation(libs.koin.android)
     testImplementation(project(":core:testing"))
 }

--- a/data/constructorimages/src/main/java/com/toquete/boxbox/data/constructorimages/di/ConstructorImagesKoinModule.kt
+++ b/data/constructorimages/src/main/java/com/toquete/boxbox/data/constructorimages/di/ConstructorImagesKoinModule.kt
@@ -1,0 +1,14 @@
+package com.toquete.boxbox.data.constructorimages.di
+
+import com.toquete.boxbox.data.constructorimages.repository.DefaultConstructorImageRepository
+import com.toquete.boxbox.data.constructorimages.source.remote.ConstructorImageRemoteDataSource
+import com.toquete.boxbox.data.constructorimages.source.remote.DefaultConstructorImageRemoteDataSource
+import com.toquete.boxbox.domain.repository.ConstructorImageRepository
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val constructorImagesModule = module {
+    singleOf(::DefaultConstructorImageRemoteDataSource) bind ConstructorImageRemoteDataSource::class
+    singleOf(::DefaultConstructorImageRepository) bind ConstructorImageRepository::class
+}


### PR DESCRIPTION
## Summary
- Adds `constructorImagesModule` Koin module providing `ConstructorImageRemoteDataSource` and `ConstructorImageRepository`
- Adds `koin-android` dependency
- No existing Hilt code removed — Hilt and Koin coexist until the full Hilt removal PR

## Part of
Phase A (Hilt → Koin) — Task A2