### PR TITLE
feat(data:constructorcolors): add Koin module

### DIFF
--- a/data/constructorcolors/build.gradle.kts
+++ b/data/constructorcolors/build.gradle.kts
@@ -11,5 +11,6 @@ dependencies {
     implementation(project(":core:database"))
     implementation(project(":core:network"))
     implementation(project(":domain"))
+    implementation(libs.koin.android)
     testImplementation(project(":core:testing"))
 }

--- a/data/constructorcolors/src/main/java/com/toquete/boxbox/data/constructorcolors/di/ConstructorColorsKoinModule.kt
+++ b/data/constructorcolors/src/main/java/com/toquete/boxbox/data/constructorcolors/di/ConstructorColorsKoinModule.kt
@@ -1,0 +1,14 @@
+package com.toquete.boxbox.data.constructorcolors.di
+
+import com.toquete.boxbox.data.constructorcolors.repository.DefaultConstructorColorRepository
+import com.toquete.boxbox.data.constructorcolors.source.remote.ConstructorColorRemoteDataSource
+import com.toquete.boxbox.data.constructorcolors.source.remote.DefaultConstructorColorRemoteDataSource
+import com.toquete.boxbox.domain.repository.ConstructorColorRepository
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val constructorColorsModule = module {
+    singleOf(::DefaultConstructorColorRemoteDataSource) bind ConstructorColorRemoteDataSource::class
+    singleOf(::DefaultConstructorColorRepository) bind ConstructorColorRepository::class
+}


### PR DESCRIPTION
## Summary
- Adds `constructorColorsModule` Koin module providing `ConstructorColorRemoteDataSource` and `ConstructorColorRepository`
- Adds `koin-android` dependency
- No existing Hilt code removed — Hilt and Koin coexist until the full Hilt removal PR

## Part of
Phase A (Hilt → Koin) — Task A2