### PR TITLE
feat(data:circuitimages): add Koin module

### DIFF
--- a/data/circuitimages/build.gradle.kts
+++ b/data/circuitimages/build.gradle.kts
@@ -11,5 +11,6 @@ dependencies {
     implementation(project(":core:database"))
     implementation(project(":core:network"))
     implementation(project(":domain"))
+    implementation(libs.koin.android)
     testImplementation(project(":core:testing"))
 }

--- a/data/circuitimages/src/main/java/com/toquete/boxbox/data/circuitimages/di/CircuitImagesKoinModule.kt
+++ b/data/circuitimages/src/main/java/com/toquete/boxbox/data/circuitimages/di/CircuitImagesKoinModule.kt
@@ -1,0 +1,14 @@
+package com.toquete.boxbox.data.circuitimages.di
+
+import com.toquete.boxbox.data.circuitimages.repository.DefaultCircuitImageRepository
+import com.toquete.boxbox.data.circuitimages.source.remote.CircuitImageRemoteDataSource
+import com.toquete.boxbox.data.circuitimages.source.remote.DefaultCircuitImageRemoteDataSource
+import com.toquete.boxbox.domain.repository.CircuitImageRepository
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val circuitImagesModule = module {
+    singleOf(::DefaultCircuitImageRemoteDataSource) bind CircuitImageRemoteDataSource::class
+    singleOf(::DefaultCircuitImageRepository) bind CircuitImageRepository::class
+}


### PR DESCRIPTION
## Summary
- Adds `circuitImagesModule` Koin module providing `CircuitImageRemoteDataSource` and `CircuitImageRepository`
- Adds `koin-android` dependency
- No existing Hilt code removed — Hilt and Koin coexist until the full Hilt removal PR

## Part of
Phase A (Hilt → Koin) — Task A2