### PR TITLE
feat(sync): add Koin module

### DIFF
--- a/sync/build.gradle.kts
+++ b/sync/build.gradle.kts
@@ -11,6 +11,8 @@ dependencies {
     implementation(project(":core:common"))
     implementation(project(":domain"))
     implementation(libs.work.runtime)
+    implementation(libs.koin.android)
+    implementation(libs.koin.workmanager)
     implementation(libs.hilt.work)
     ksp(libs.hilt.work.compiler)
     implementation(libs.timber)

--- a/sync/src/main/java/com/toquete/boxbox/sync/di/SyncKoinModule.kt
+++ b/sync/src/main/java/com/toquete/boxbox/sync/di/SyncKoinModule.kt
@@ -1,0 +1,22 @@
+package com.toquete.boxbox.sync.di
+
+import com.toquete.boxbox.core.common.util.SyncMonitor
+import com.toquete.boxbox.domain.repository.SyncRepository
+import com.toquete.boxbox.sync.monitor.WorkManagerSyncMonitor
+import com.toquete.boxbox.sync.repository.DefaultSyncRepository
+import com.toquete.boxbox.sync.repository.ImagesRepository
+import com.toquete.boxbox.sync.repository.StandingsRepository
+import com.toquete.boxbox.sync.worker.SyncWorker
+import org.koin.android.ext.koin.androidContext
+import org.koin.androidx.workmanager.dsl.workerOf
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+val syncModule = module {
+    workerOf(::SyncWorker)
+    single<SyncMonitor> { WorkManagerSyncMonitor(androidContext()) }
+    singleOf(::StandingsRepository)
+    singleOf(::ImagesRepository)
+    singleOf(::DefaultSyncRepository) bind SyncRepository::class
+}


### PR DESCRIPTION
## Summary
- Adds `syncModule` Koin module providing `WorkManagerSyncMonitor`, `StandingsRepository`, `ImagesRepository`, `SyncWorker` (via `workerOf`), and `SyncRepository`
- Adds `koin-android` and `koin-workmanager` dependencies
- No existing Hilt code removed — Hilt and Koin coexist until the full Hilt removal PR

## Part of
Phase A (Hilt → Koin) — Task A3.1