### PR TITLE
feat(feature:standings): add Koin module

### DIFF
--- a/feature/standings/build.gradle.kts
+++ b/feature/standings/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:navigation"))
     implementation(project(":domain"))
+    implementation(libs.koin.android)
+    implementation(libs.koin.compose)
 
     testImplementation(project(":core:testing"))
     testImplementation(libs.robolectric)

--- a/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/di/StandingsKoinModule.kt
+++ b/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/di/StandingsKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.feature.standings.di
+
+import com.toquete.boxbox.feature.standings.constructors.ConstructorStandingsViewModel
+import com.toquete.boxbox.feature.standings.drivers.DriverStandingsViewModel
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.module
+
+internal val standingsModule = module {
+    viewModelOf(::DriverStandingsViewModel)
+    viewModelOf(::ConstructorStandingsViewModel)
+}


### PR DESCRIPTION
## Summary
- Adds `standingsModule` Koin module with `viewModelOf` for `DriverStandingsViewModel` and `ConstructorStandingsViewModel`
- Adds `koin-android` and `koin-compose` dependencies
- No existing Hilt code removed — Hilt and Koin coexist until the full Hilt removal PR

## Part of
Phase A (Hilt → Koin) — Task A3.2