### PR TITLE
feat(feature:races): add Koin module

### DIFF
--- a/feature/races/build.gradle.kts
+++ b/feature/races/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:navigation"))
     implementation(project(":domain"))
+    implementation(libs.koin.android)
+    implementation(libs.koin.compose)
 
     testImplementation(project(":core:testing"))
     testImplementation(libs.robolectric)

--- a/feature/races/src/main/java/com/toquete/boxbox/feature/races/di/RacesFeatureKoinModule.kt
+++ b/feature/races/src/main/java/com/toquete/boxbox/feature/races/di/RacesFeatureKoinModule.kt
@@ -1,0 +1,9 @@
+package com.toquete.boxbox.feature.races.di
+
+import com.toquete.boxbox.feature.races.ui.RacesViewModel
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.module
+
+internal val racesFeatureModule = module {
+    viewModelOf(::RacesViewModel)
+}


### PR DESCRIPTION
## Summary
- Adds `racesFeatureModule` Koin module with `viewModelOf` for `RacesViewModel`
- Adds `koin-android` and `koin-compose` dependencies
- No existing Hilt code removed — Hilt and Koin coexist until the full Hilt removal PR

## Part of
Phase A (Hilt → Koin) — Task A3.3