### PR TITLE
feat(feature:raceresults): add Koin module

### DIFF
--- a/feature/raceresults/build.gradle.kts
+++ b/feature/raceresults/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:navigation"))
     implementation(project(":domain"))
+    implementation(libs.koin.android)
+    implementation(libs.koin.compose)
 
     testImplementation(project(":core:testing"))
     testImplementation(libs.robolectric)

--- a/feature/raceresults/src/main/java/com/toquete/boxbox/feature/raceresults/di/RaceResultsFeatureKoinModule.kt
+++ b/feature/raceresults/src/main/java/com/toquete/boxbox/feature/raceresults/di/RaceResultsFeatureKoinModule.kt
@@ -1,0 +1,9 @@
+package com.toquete.boxbox.feature.raceresults.di
+
+import com.toquete.boxbox.feature.raceresults.ui.RaceResultsViewModel
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.module
+
+internal val raceResultsFeatureModule = module {
+    viewModelOf(::RaceResultsViewModel)
+}


### PR DESCRIPTION
## Summary
- Adds `raceResultsFeatureModule` Koin module with `viewModelOf` for `RaceResultsViewModel` (handles `SavedStateHandle` automatically)
- Adds `koin-android` and `koin-compose` dependencies
- No existing Hilt code removed — Hilt and Koin coexist until the full Hilt removal PR

## Part of
Phase A (Hilt → Koin) — Task A3.4