### PR TITLE
feat(feature:settings): add Koin module

### DIFF
--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:navigation"))
     implementation(project(":domain"))
+    implementation(libs.koin.android)
+    implementation(libs.koin.compose)
 
     testImplementation(project(":core:testing"))
     testImplementation(libs.robolectric)

--- a/feature/settings/src/main/java/com/toquete/boxbox/feature/settings/di/SettingsKoinModule.kt
+++ b/feature/settings/src/main/java/com/toquete/boxbox/feature/settings/di/SettingsKoinModule.kt
@@ -1,0 +1,9 @@
+package com.toquete.boxbox.feature.settings.di
+
+import com.toquete.boxbox.feature.settings.ui.SettingsViewModel
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.module
+
+val settingsModule = module {
+    viewModelOf(::SettingsViewModel)
+}


### PR DESCRIPTION
## Summary
- Adds `settingsModule` Koin module with `viewModelOf` for `SettingsViewModel`
- Adds `koin-android` and `koin-compose` dependencies
- No existing Hilt code removed — Hilt and Koin coexist until the full Hilt removal PR

## Part of
Phase A (Hilt → Koin) — Task A3.5