### PR TITLE
feat(app): wire startKoin in BoxBoxApplication (A4)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -128,6 +128,7 @@ dependencies {
     implementation(libs.hilt.work)
     ksp(libs.hilt.work.compiler)
     implementation(libs.koin.android)
+    implementation(libs.koin.compose)
     implementation(libs.koin.workmanager)
     testImplementation(libs.koin.test)
     testImplementation(libs.koin.test.junit4)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,6 +99,9 @@ android {
 
 dependencies {
     implementation(project(":core:ui"))
+    implementation(project(":core:common"))
+    implementation(project(":core:network"))
+    implementation(project(":core:database"))
     implementation(project(":core:preferences"))
     implementation(project(":core:navigation"))
     implementation(project(":data:driverimages"))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -141,8 +141,9 @@ dependencies {
     testImplementation(libs.work.testing)
     androidTestImplementation(project(":core:testing"))
     androidTestImplementation(libs.compose.navigation.test)
-    androidTestImplementation(libs.hilt.android.testing)
-    kspAndroidTest(libs.hilt.android.compiler)
+    androidTestImplementation(libs.koin.android)
+    androidTestImplementation(libs.koin.test)
+    androidTestImplementation(libs.koin.test.junit4)
 }
 
 kover {

--- a/app/src/androidTest/java/com/toquete/boxbox/BoxBoxTestRunner.kt
+++ b/app/src/androidTest/java/com/toquete/boxbox/BoxBoxTestRunner.kt
@@ -3,11 +3,10 @@ package com.toquete.boxbox
 import android.app.Application
 import android.content.Context
 import androidx.test.runner.AndroidJUnitRunner
-import dagger.hilt.android.testing.HiltTestApplication
 
 class BoxBoxTestRunner : AndroidJUnitRunner() {
 
     override fun newApplication(cl: ClassLoader?, className: String?, context: Context?): Application? {
-        return super.newApplication(cl, HiltTestApplication::class.java.name, context)
+        return super.newApplication(cl, KoinTestApplication::class.java.name, context)
     }
 }

--- a/app/src/androidTest/java/com/toquete/boxbox/KoinTestApplication.kt
+++ b/app/src/androidTest/java/com/toquete/boxbox/KoinTestApplication.kt
@@ -1,0 +1,29 @@
+package com.toquete.boxbox
+
+import android.app.Application
+import com.toquete.boxbox.di.testModule
+import com.toquete.boxbox.domain.di.domainModule
+import com.toquete.boxbox.feature.raceresults.di.raceResultsFeatureModule
+import com.toquete.boxbox.feature.races.di.racesFeatureModule
+import com.toquete.boxbox.feature.settings.di.settingsModule
+import com.toquete.boxbox.feature.standings.di.standingsModule
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.startKoin
+
+class KoinTestApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        startKoin {
+            androidContext(this@KoinTestApplication)
+            modules(
+                testModule,
+                domainModule,
+                standingsModule,
+                racesFeatureModule,
+                raceResultsFeatureModule,
+                settingsModule
+            )
+        }
+    }
+}

--- a/app/src/androidTest/java/com/toquete/boxbox/NavigationTest.kt
+++ b/app/src/androidTest/java/com/toquete/boxbox/NavigationTest.kt
@@ -20,28 +20,21 @@ import com.toquete.boxbox.core.ui.theme.BoxBoxTheme
 import com.toquete.boxbox.domain.repository.RaceRepository
 import com.toquete.boxbox.ui.HomeRoute
 import com.toquete.boxbox.ui.MainActivity
-import dagger.hilt.android.testing.HiltAndroidRule
-import dagger.hilt.android.testing.HiltAndroidTest
-import jakarta.inject.Inject
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.koin.java.KoinJavaComponent.get
 import com.toquete.boxbox.feature.settings.R as settingsR
 import com.toquete.boxbox.feature.standings.R as standingsR
 
-@HiltAndroidTest
 class NavigationTest {
 
-    @get:Rule(order = 0)
-    val hiltRule = HiltAndroidRule(this)
-
-    @get:Rule(order = 1)
+    @get:Rule
     val composeTestRule = createAndroidComposeRule<MainActivity>()
 
-    @Inject
-    lateinit var raceRepository: RaceRepository
+    private val raceRepository: RaceRepository = get(RaceRepository::class.java)
 
     private lateinit var navController: TestNavHostController
     private val appName by composeTestRule.stringResource(R.string.app_name)
@@ -53,7 +46,6 @@ class NavigationTest {
 
     @Before
     fun setupAppNavHost() {
-        hiltRule.inject()
         composeTestRule.activity.setContent {
             navController = TestNavHostController(LocalContext.current).apply {
                 navigatorProvider.addNavigator(ComposeNavigator())

--- a/app/src/androidTest/java/com/toquete/boxbox/di/TestModule.kt
+++ b/app/src/androidTest/java/com/toquete/boxbox/di/TestModule.kt
@@ -2,18 +2,6 @@ package com.toquete.boxbox.di
 
 import com.toquete.boxbox.core.common.util.NetworkMonitor
 import com.toquete.boxbox.core.common.util.SyncMonitor
-import com.toquete.boxbox.core.preferences.di.UserPreferencesRepositoryModule
-import com.toquete.boxbox.data.circuitimages.di.CircuitImageRepositoryModule
-import com.toquete.boxbox.sync.di.SyncMonitorModule
-import com.toquete.boxbox.data.constructorcolors.di.ConstructorColorRepositoryModule
-import com.toquete.boxbox.data.constructorimages.di.ConstructorImageRepositoryModule
-import com.toquete.boxbox.data.constructorstandings.di.ConstructorStandingsRepositoryModule
-import com.toquete.boxbox.data.countries.di.CountryRepositoryModule
-import com.toquete.boxbox.data.driverimages.di.DriverImageRepositoryModule
-import com.toquete.boxbox.data.driverstandings.di.DriverStandingsRepositoryModule
-import com.toquete.boxbox.data.raceresults.di.RaceResultRepositoryModule
-import com.toquete.boxbox.data.races.di.RaceRepositoryModule
-import com.toquete.boxbox.data.sprintresults.di.SprintResultRepositoryModule
 import com.toquete.boxbox.domain.repository.CircuitImageRepository
 import com.toquete.boxbox.domain.repository.ConstructorColorRepository
 import com.toquete.boxbox.domain.repository.ConstructorImageRepository
@@ -23,7 +11,9 @@ import com.toquete.boxbox.domain.repository.DriverImageRepository
 import com.toquete.boxbox.domain.repository.DriverStandingsRepository
 import com.toquete.boxbox.domain.repository.RaceRepository
 import com.toquete.boxbox.domain.repository.RaceResultRepository
+import com.toquete.boxbox.domain.repository.RemoteConfigRepository
 import com.toquete.boxbox.domain.repository.SprintResultRepository
+import com.toquete.boxbox.domain.repository.SyncRepository
 import com.toquete.boxbox.domain.repository.UserPreferencesRepository
 import com.toquete.boxbox.fake.FakeCircuitImageRepository
 import com.toquete.boxbox.fake.FakeConstructorColorRepository
@@ -35,85 +25,34 @@ import com.toquete.boxbox.fake.FakeDriverStandingsRepository
 import com.toquete.boxbox.fake.FakeNetworkMonitor
 import com.toquete.boxbox.fake.FakeRaceRepository
 import com.toquete.boxbox.fake.FakeRaceResultRepository
+import com.toquete.boxbox.fake.FakeRemoteConfigRepository
 import com.toquete.boxbox.fake.FakeSprintResultRepository
 import com.toquete.boxbox.fake.FakeSyncMonitor
+import com.toquete.boxbox.fake.FakeSyncRepository
 import com.toquete.boxbox.fake.FakeUserPreferencesRepository
-import dagger.Module
-import dagger.Provides
-import dagger.hilt.components.SingletonComponent
-import dagger.hilt.testing.TestInstallIn
-import javax.inject.Singleton
+import com.toquete.boxbox.ui.HomeViewModel
+import com.toquete.boxbox.ui.MainViewModel
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
 
-@Module
-@TestInstallIn(
-    components = [SingletonComponent::class],
-    replaces = [
-        CircuitImageRepositoryModule::class,
-        ConstructorColorRepositoryModule::class,
-        ConstructorImageRepositoryModule::class,
-        ConstructorStandingsRepositoryModule::class,
-        CountryRepositoryModule::class,
-        DriverImageRepositoryModule::class,
-        DriverStandingsRepositoryModule::class,
-        RaceResultRepositoryModule::class,
-        RaceRepositoryModule::class,
-        SprintResultRepositoryModule::class,
-        MonitorModule::class,
-        SyncMonitorModule::class,
-        UserPreferencesRepositoryModule::class
-    ]
-)
-object TestModule {
+val testModule = module {
+    single<CircuitImageRepository> { FakeCircuitImageRepository() }
+    single<ConstructorColorRepository> { FakeConstructorColorRepository() }
+    single<ConstructorImageRepository> { FakeConstructorImageRepository() }
+    single<ConstructorStandingsRepository> { FakeConstructorStandingsRepository() }
+    single<CountryRepository> { FakeCountryRepository() }
+    single<DriverImageRepository> { FakeDriverImageRepository() }
+    single<DriverStandingsRepository> { FakeDriverStandingsRepository() }
+    single<RaceResultRepository> { FakeRaceResultRepository() }
+    single<RaceRepository> { FakeRaceRepository() }
+    single<SprintResultRepository> { FakeSprintResultRepository() }
+    single<NetworkMonitor> { FakeNetworkMonitor() }
+    single<SyncMonitor> { FakeSyncMonitor() }
+    single<UserPreferencesRepository> { FakeUserPreferencesRepository() }
+    single<RemoteConfigRepository> { FakeRemoteConfigRepository() }
+    single<SyncRepository> { FakeSyncRepository() }
 
-    @Provides
-    @Singleton
-    fun providesCircuitImageRepository(): CircuitImageRepository = FakeCircuitImageRepository()
-
-    @Provides
-    @Singleton
-    fun providesConstructorColorRepository(): ConstructorColorRepository = FakeConstructorColorRepository()
-
-    @Provides
-    @Singleton
-    fun providesConstructorImageRepository(): ConstructorImageRepository = FakeConstructorImageRepository()
-
-    @Provides
-    @Singleton
-    fun providesConstructorStandingsRepository(): ConstructorStandingsRepository = FakeConstructorStandingsRepository()
-
-    @Provides
-    @Singleton
-    fun providesCountryRepository(): CountryRepository = FakeCountryRepository()
-
-    @Provides
-    @Singleton
-    fun providesDriverImageRepository(): DriverImageRepository = FakeDriverImageRepository()
-
-    @Provides
-    @Singleton
-    fun providesDriverStandingsRepository(): DriverStandingsRepository = FakeDriverStandingsRepository()
-
-    @Provides
-    @Singleton
-    fun providesRaceResultRepository(): RaceResultRepository = FakeRaceResultRepository()
-
-    @Provides
-    @Singleton
-    fun providesRaceRepository(): RaceRepository = FakeRaceRepository()
-
-    @Provides
-    @Singleton
-    fun providesSprintResultRepository(): SprintResultRepository = FakeSprintResultRepository()
-
-    @Provides
-    @Singleton
-    fun providesNetworkMonitor(): NetworkMonitor = FakeNetworkMonitor()
-
-    @Provides
-    @Singleton
-    fun providesSyncMonitor(): SyncMonitor = FakeSyncMonitor()
-
-    @Provides
-    @Singleton
-    fun providesUserPreferencesRepository(): UserPreferencesRepository = FakeUserPreferencesRepository()
+    viewModelOf(::MainViewModel)
+    viewModelOf(::HomeViewModel)
 }

--- a/app/src/androidTest/java/com/toquete/boxbox/fake/FakeRemoteConfigRepository.kt
+++ b/app/src/androidTest/java/com/toquete/boxbox/fake/FakeRemoteConfigRepository.kt
@@ -1,0 +1,13 @@
+package com.toquete.boxbox.fake
+
+import com.toquete.boxbox.core.model.RemoteConfigs
+import com.toquete.boxbox.domain.repository.RemoteConfigRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class FakeRemoteConfigRepository : RemoteConfigRepository {
+    override val remoteConfigs: Flow<RemoteConfigs>
+        get() = flowOf(RemoteConfigs())
+
+    override fun fetchAndActivate(): Flow<Boolean> = flowOf(true)
+}

--- a/app/src/androidTest/java/com/toquete/boxbox/fake/FakeSyncRepository.kt
+++ b/app/src/androidTest/java/com/toquete/boxbox/fake/FakeSyncRepository.kt
@@ -1,0 +1,7 @@
+package com.toquete.boxbox.fake
+
+import com.toquete.boxbox.domain.repository.SyncRepository
+
+class FakeSyncRepository : SyncRepository {
+    override suspend fun sync() = Unit
+}

--- a/app/src/debug/java/com/toquete/boxbox/di/AppCheckKoinModule.kt
+++ b/app/src/debug/java/com/toquete/boxbox/di/AppCheckKoinModule.kt
@@ -1,0 +1,9 @@
+package com.toquete.boxbox.di
+
+import com.google.firebase.appcheck.AppCheckProviderFactory
+import com.google.firebase.appcheck.debug.DebugAppCheckProviderFactory
+import org.koin.dsl.module
+
+val appCheckModule = module {
+    single<AppCheckProviderFactory> { DebugAppCheckProviderFactory.getInstance() }
+}

--- a/app/src/debug/java/com/toquete/boxbox/di/TreeKoinModule.kt
+++ b/app/src/debug/java/com/toquete/boxbox/di/TreeKoinModule.kt
@@ -1,0 +1,8 @@
+package com.toquete.boxbox.di
+
+import org.koin.dsl.module
+import timber.log.Timber
+
+val treeModule = module {
+    single<Timber.Tree> { Timber.DebugTree() }
+}

--- a/app/src/main/java/com/toquete/boxbox/BoxBoxApplication.kt
+++ b/app/src/main/java/com/toquete/boxbox/BoxBoxApplication.kt
@@ -2,8 +2,6 @@ package com.toquete.boxbox
 
 import android.app.Application
 import androidx.core.content.edit
-import androidx.hilt.work.HiltWorkerFactory
-import androidx.work.Configuration
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.WorkManager
 import coil3.ImageLoader
@@ -24,16 +22,40 @@ import com.google.firebase.remoteconfig.ConfigUpdateListener
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigException
 import com.google.firebase.remoteconfig.remoteConfig
 import com.google.firebase.remoteconfig.remoteConfigSettings
-import com.toquete.boxbox.core.common.annotation.IoDispatcher
+import com.toquete.boxbox.core.common.di.commonModule
+import com.toquete.boxbox.core.database.di.databaseModule
+import com.toquete.boxbox.core.network.di.networkModule
+import com.toquete.boxbox.core.preferences.di.preferencesModule
+import com.toquete.boxbox.data.circuitimages.di.circuitImagesModule
+import com.toquete.boxbox.data.constructorcolors.di.constructorColorsModule
+import com.toquete.boxbox.data.constructorimages.di.constructorImagesModule
+import com.toquete.boxbox.data.constructorstandings.di.constructorStandingsModule
+import com.toquete.boxbox.data.countries.di.countriesModule
+import com.toquete.boxbox.data.driverimages.di.driverImagesModule
+import com.toquete.boxbox.data.driverstandings.di.driverStandingsModule
+import com.toquete.boxbox.data.raceresults.di.raceResultsModule
+import com.toquete.boxbox.data.races.di.racesModule
+import com.toquete.boxbox.data.sprintresults.di.sprintResultsModule
+import com.toquete.boxbox.di.appCheckModule
+import com.toquete.boxbox.di.appModule
+import com.toquete.boxbox.di.treeModule
+import com.toquete.boxbox.domain.di.domainModule
+import com.toquete.boxbox.feature.raceresults.di.raceResultsFeatureModule
+import com.toquete.boxbox.feature.races.di.racesFeatureModule
+import com.toquete.boxbox.feature.settings.di.settingsModule
+import com.toquete.boxbox.feature.standings.di.standingsModule
+import com.toquete.boxbox.sync.di.syncModule
 import com.toquete.boxbox.sync.worker.SYNC_WORK_NAME
 import com.toquete.boxbox.sync.worker.SyncWorker
 import com.toquete.boxbox.util.remoteconfig.remoteConfigDefaults
-import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import okio.Path.Companion.toOkioPath
+import org.koin.android.ext.android.inject
+import org.koin.android.ext.koin.androidContext
+import org.koin.androidx.workmanager.koin.workManagerFactory
+import org.koin.core.context.startKoin
 import timber.log.Timber
-import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
 private const val APP_CHECK_DEBUG_STORE = "com.google.firebase.appcheck.debug.store.%s"
@@ -42,29 +64,43 @@ private const val MEMORY_CACHE_PERCENT = 0.1
 private const val DISK_CACHE_PERCENT = 0.03
 private const val MINIMUM_REMOTE_CONFIG_FETCH_INTERVAL = 0L
 
-@HiltAndroidApp
-class BoxBoxApplication : Application(), Configuration.Provider, SingletonImageLoader.Factory {
+class BoxBoxApplication : Application(), SingletonImageLoader.Factory {
 
-    @Inject
-    lateinit var workerFactory: HiltWorkerFactory
-
-    @Inject
-    lateinit var timberTree: Timber.Tree
-
-    @Inject
-    lateinit var appCheckProviderFactory: AppCheckProviderFactory
-
-    @Inject
-    @IoDispatcher
-    lateinit var ioDispatcher: CoroutineContext
-
-    override val workManagerConfiguration: Configuration
-        get() = Configuration.Builder()
-            .setWorkerFactory(workerFactory)
-            .build()
+    private val timberTree: Timber.Tree by inject()
+    private val appCheckProviderFactory: AppCheckProviderFactory by inject()
+    private val ioDispatcher: CoroutineContext by inject()
 
     override fun onCreate() {
         super.onCreate()
+        startKoin {
+            androidContext(this@BoxBoxApplication)
+            workManagerFactory()
+            modules(
+                commonModule,
+                networkModule,
+                databaseModule,
+                preferencesModule,
+                domainModule,
+                driverStandingsModule,
+                constructorStandingsModule,
+                driverImagesModule,
+                constructorImagesModule,
+                constructorColorsModule,
+                circuitImagesModule,
+                racesModule,
+                raceResultsModule,
+                sprintResultsModule,
+                countriesModule,
+                syncModule,
+                standingsModule,
+                racesFeatureModule,
+                raceResultsFeatureModule,
+                settingsModule,
+                appCheckModule,
+                treeModule,
+                appModule
+            )
+        }
         setupAppCheck()
         setupSyncWork()
         setupTimber()

--- a/app/src/main/java/com/toquete/boxbox/ui/HomeScreen.kt
+++ b/app/src/main/java/com/toquete/boxbox/ui/HomeScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
@@ -41,13 +40,14 @@ import com.toquete.boxbox.core.ui.annotation.UiModePreviews
 import com.toquete.boxbox.core.ui.theme.BoxBoxTheme
 import com.toquete.boxbox.feature.settings.ui.SettingsScreen
 import com.toquete.boxbox.navigation.BoxBoxNavHost
+import org.koin.androidx.compose.koinViewModel
 
 private const val SNACKBAR_OFFSET = -64
 
 @Composable
 internal fun HomeRoute(
     navController: NavHostController,
-    viewModel: HomeViewModel = hiltViewModel()
+    viewModel: HomeViewModel = koinViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     HomeScreen(

--- a/app/src/main/java/com/toquete/boxbox/ui/HomeViewModel.kt
+++ b/app/src/main/java/com/toquete/boxbox/ui/HomeViewModel.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
-internal class HomeViewModel constructor(
+internal class HomeViewModel(
     syncMonitor: SyncMonitor,
     networkMonitor: NetworkMonitor,
     private val syncRepository: SyncRepository,

--- a/app/src/main/java/com/toquete/boxbox/ui/HomeViewModel.kt
+++ b/app/src/main/java/com/toquete/boxbox/ui/HomeViewModel.kt
@@ -10,7 +10,6 @@ import com.toquete.boxbox.core.common.util.SyncMonitor
 import com.toquete.boxbox.core.ui.custom.SnackbarManager
 import com.toquete.boxbox.domain.repository.RemoteConfigRepository
 import com.toquete.boxbox.domain.repository.SyncRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -20,10 +19,8 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import javax.inject.Inject
 
-@HiltViewModel
-internal class HomeViewModel @Inject constructor(
+internal class HomeViewModel constructor(
     syncMonitor: SyncMonitor,
     networkMonitor: NetworkMonitor,
     private val syncRepository: SyncRepository,

--- a/app/src/main/java/com/toquete/boxbox/ui/MainActivity.kt
+++ b/app/src/main/java/com/toquete/boxbox/ui/MainActivity.kt
@@ -6,7 +6,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.viewModels
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -21,15 +20,14 @@ import androidx.navigation.compose.rememberNavController
 import com.toquete.boxbox.core.model.ColorConfig
 import com.toquete.boxbox.core.model.DarkThemeConfig
 import com.toquete.boxbox.core.ui.theme.BoxBoxTheme
-import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
-@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
-    private val viewModel: MainViewModel by viewModels()
+    private val viewModel: MainViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()

--- a/app/src/main/java/com/toquete/boxbox/ui/MainViewModel.kt
+++ b/app/src/main/java/com/toquete/boxbox/ui/MainViewModel.kt
@@ -4,16 +4,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.toquete.boxbox.domain.repository.RemoteConfigRepository
 import com.toquete.boxbox.domain.repository.UserPreferencesRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
-import javax.inject.Inject
 
-@HiltViewModel
-class MainViewModel @Inject constructor(
+class MainViewModel constructor(
     preferencesRepository: UserPreferencesRepository,
     remoteConfigRepository: RemoteConfigRepository
 ) : ViewModel() {

--- a/app/src/main/java/com/toquete/boxbox/ui/MainViewModel.kt
+++ b/app/src/main/java/com/toquete/boxbox/ui/MainViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 
-class MainViewModel constructor(
+class MainViewModel(
     preferencesRepository: UserPreferencesRepository,
     remoteConfigRepository: RemoteConfigRepository
 ) : ViewModel() {

--- a/app/src/minified/java/com/toquete/boxbox/di/AppCheckKoinModule.kt
+++ b/app/src/minified/java/com/toquete/boxbox/di/AppCheckKoinModule.kt
@@ -1,0 +1,9 @@
+package com.toquete.boxbox.di
+
+import com.google.firebase.appcheck.AppCheckProviderFactory
+import com.google.firebase.appcheck.debug.DebugAppCheckProviderFactory
+import org.koin.dsl.module
+
+val appCheckModule = module {
+    single<AppCheckProviderFactory> { DebugAppCheckProviderFactory.getInstance() }
+}

--- a/app/src/minified/java/com/toquete/boxbox/di/TreeKoinModule.kt
+++ b/app/src/minified/java/com/toquete/boxbox/di/TreeKoinModule.kt
@@ -1,0 +1,8 @@
+package com.toquete.boxbox.di
+
+import org.koin.dsl.module
+import timber.log.Timber
+
+val treeModule = module {
+    single<Timber.Tree> { Timber.DebugTree() }
+}

--- a/app/src/release/java/com/toquete/boxbox/di/AppCheckKoinModule.kt
+++ b/app/src/release/java/com/toquete/boxbox/di/AppCheckKoinModule.kt
@@ -1,0 +1,9 @@
+package com.toquete.boxbox.di
+
+import com.google.firebase.appcheck.AppCheckProviderFactory
+import com.google.firebase.appcheck.playintegrity.PlayIntegrityAppCheckProviderFactory
+import org.koin.dsl.module
+
+val appCheckModule = module {
+    single<AppCheckProviderFactory> { PlayIntegrityAppCheckProviderFactory.getInstance() }
+}

--- a/app/src/release/java/com/toquete/boxbox/di/TreeKoinModule.kt
+++ b/app/src/release/java/com/toquete/boxbox/di/TreeKoinModule.kt
@@ -1,0 +1,10 @@
+package com.toquete.boxbox.di
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.toquete.boxbox.util.log.CrashlyticsReportingTree
+import org.koin.dsl.module
+import timber.log.Timber
+
+val treeModule = module {
+    single<Timber.Tree> { CrashlyticsReportingTree(get<FirebaseCrashlytics>()) }
+}

--- a/data/circuitimages/src/demo/java/com/toquete/boxbox/data/circuitimages/di/RemoteDataSourceKoinModule.kt
+++ b/data/circuitimages/src/demo/java/com/toquete/boxbox/data/circuitimages/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.circuitimages.di
+
+import com.toquete.boxbox.data.circuitimages.source.remote.CircuitImageRemoteDataSource
+import com.toquete.boxbox.data.circuitimages.source.remote.DefaultCircuitImageRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultCircuitImageRemoteDataSource) bind CircuitImageRemoteDataSource::class
+}

--- a/data/circuitimages/src/main/java/com/toquete/boxbox/data/circuitimages/di/CircuitImagesKoinModule.kt
+++ b/data/circuitimages/src/main/java/com/toquete/boxbox/data/circuitimages/di/CircuitImagesKoinModule.kt
@@ -1,14 +1,12 @@
 package com.toquete.boxbox.data.circuitimages.di
 
 import com.toquete.boxbox.data.circuitimages.repository.DefaultCircuitImageRepository
-import com.toquete.boxbox.data.circuitimages.source.remote.CircuitImageRemoteDataSource
-import com.toquete.boxbox.data.circuitimages.source.remote.DefaultCircuitImageRemoteDataSource
 import com.toquete.boxbox.domain.repository.CircuitImageRepository
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
-internal val circuitImagesModule = module {
-    singleOf(::DefaultCircuitImageRemoteDataSource) bind CircuitImageRemoteDataSource::class
+val circuitImagesModule = module {
+    includes(remoteDataSourceModule)
     singleOf(::DefaultCircuitImageRepository) bind CircuitImageRepository::class
 }

--- a/data/circuitimages/src/prod/java/com/toquete/boxbox/data/circuitimages/di/RemoteDataSourceKoinModule.kt
+++ b/data/circuitimages/src/prod/java/com/toquete/boxbox/data/circuitimages/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.circuitimages.di
+
+import com.toquete.boxbox.data.circuitimages.source.remote.CircuitImageRemoteDataSource
+import com.toquete.boxbox.data.circuitimages.source.remote.DefaultCircuitImageRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultCircuitImageRemoteDataSource) bind CircuitImageRemoteDataSource::class
+}

--- a/data/constructorcolors/src/demo/java/com/toquete/boxbox/data/constructorcolors/di/RemoteDataSourceKoinModule.kt
+++ b/data/constructorcolors/src/demo/java/com/toquete/boxbox/data/constructorcolors/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.constructorcolors.di
+
+import com.toquete.boxbox.data.constructorcolors.source.remote.ConstructorColorRemoteDataSource
+import com.toquete.boxbox.data.constructorcolors.source.remote.DefaultConstructorColorRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultConstructorColorRemoteDataSource) bind ConstructorColorRemoteDataSource::class
+}

--- a/data/constructorcolors/src/main/java/com/toquete/boxbox/data/constructorcolors/di/ConstructorColorsKoinModule.kt
+++ b/data/constructorcolors/src/main/java/com/toquete/boxbox/data/constructorcolors/di/ConstructorColorsKoinModule.kt
@@ -1,14 +1,12 @@
 package com.toquete.boxbox.data.constructorcolors.di
 
 import com.toquete.boxbox.data.constructorcolors.repository.DefaultConstructorColorRepository
-import com.toquete.boxbox.data.constructorcolors.source.remote.ConstructorColorRemoteDataSource
-import com.toquete.boxbox.data.constructorcolors.source.remote.DefaultConstructorColorRemoteDataSource
 import com.toquete.boxbox.domain.repository.ConstructorColorRepository
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
-internal val constructorColorsModule = module {
-    singleOf(::DefaultConstructorColorRemoteDataSource) bind ConstructorColorRemoteDataSource::class
+val constructorColorsModule = module {
+    includes(remoteDataSourceModule)
     singleOf(::DefaultConstructorColorRepository) bind ConstructorColorRepository::class
 }

--- a/data/constructorcolors/src/prod/java/com/toquete/boxbox/data/constructorcolors/di/RemoteDataSourceKoinModule.kt
+++ b/data/constructorcolors/src/prod/java/com/toquete/boxbox/data/constructorcolors/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.constructorcolors.di
+
+import com.toquete.boxbox.data.constructorcolors.source.remote.ConstructorColorRemoteDataSource
+import com.toquete.boxbox.data.constructorcolors.source.remote.DefaultConstructorColorRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultConstructorColorRemoteDataSource) bind ConstructorColorRemoteDataSource::class
+}

--- a/data/constructorimages/src/demo/java/com/toquete/boxbox/data/constructorimages/di/RemoteDataSourceKoinModule.kt
+++ b/data/constructorimages/src/demo/java/com/toquete/boxbox/data/constructorimages/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.constructorimages.di
+
+import com.toquete.boxbox.data.constructorimages.source.remote.ConstructorImageRemoteDataSource
+import com.toquete.boxbox.data.constructorimages.source.remote.DefaultConstructorImageRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultConstructorImageRemoteDataSource) bind ConstructorImageRemoteDataSource::class
+}

--- a/data/constructorimages/src/main/java/com/toquete/boxbox/data/constructorimages/di/ConstructorImagesKoinModule.kt
+++ b/data/constructorimages/src/main/java/com/toquete/boxbox/data/constructorimages/di/ConstructorImagesKoinModule.kt
@@ -1,14 +1,12 @@
 package com.toquete.boxbox.data.constructorimages.di
 
 import com.toquete.boxbox.data.constructorimages.repository.DefaultConstructorImageRepository
-import com.toquete.boxbox.data.constructorimages.source.remote.ConstructorImageRemoteDataSource
-import com.toquete.boxbox.data.constructorimages.source.remote.DefaultConstructorImageRemoteDataSource
 import com.toquete.boxbox.domain.repository.ConstructorImageRepository
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
-internal val constructorImagesModule = module {
-    singleOf(::DefaultConstructorImageRemoteDataSource) bind ConstructorImageRemoteDataSource::class
+val constructorImagesModule = module {
+    includes(remoteDataSourceModule)
     singleOf(::DefaultConstructorImageRepository) bind ConstructorImageRepository::class
 }

--- a/data/constructorimages/src/prod/java/com/toquete/boxbox/data/constructorimages/di/RemoteDataSourceKoinModule.kt
+++ b/data/constructorimages/src/prod/java/com/toquete/boxbox/data/constructorimages/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.constructorimages.di
+
+import com.toquete.boxbox.data.constructorimages.source.remote.ConstructorImageRemoteDataSource
+import com.toquete.boxbox.data.constructorimages.source.remote.DefaultConstructorImageRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultConstructorImageRemoteDataSource) bind ConstructorImageRemoteDataSource::class
+}

--- a/data/constructorstandings/src/demo/java/com/toquete/boxbox/data/constructorstandings/di/RemoteDataSourceKoinModule.kt
+++ b/data/constructorstandings/src/demo/java/com/toquete/boxbox/data/constructorstandings/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.constructorstandings.di
+
+import com.toquete.boxbox.data.constructorstandings.source.remote.ConstructorStandingsRemoteDataSource
+import com.toquete.boxbox.data.constructorstandings.source.remote.DefaultConstructorStandingsRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultConstructorStandingsRemoteDataSource) bind ConstructorStandingsRemoteDataSource::class
+}

--- a/data/constructorstandings/src/main/java/com/toquete/boxbox/data/constructorstandings/di/ConstructorStandingsKoinModule.kt
+++ b/data/constructorstandings/src/main/java/com/toquete/boxbox/data/constructorstandings/di/ConstructorStandingsKoinModule.kt
@@ -1,14 +1,12 @@
 package com.toquete.boxbox.data.constructorstandings.di
 
 import com.toquete.boxbox.data.constructorstandings.repository.DefaultConstructorStandingsRepository
-import com.toquete.boxbox.data.constructorstandings.source.remote.ConstructorStandingsRemoteDataSource
-import com.toquete.boxbox.data.constructorstandings.source.remote.DefaultConstructorStandingsRemoteDataSource
 import com.toquete.boxbox.domain.repository.ConstructorStandingsRepository
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
-internal val constructorStandingsModule = module {
-    singleOf(::DefaultConstructorStandingsRemoteDataSource) bind ConstructorStandingsRemoteDataSource::class
+val constructorStandingsModule = module {
+    includes(remoteDataSourceModule)
     singleOf(::DefaultConstructorStandingsRepository) bind ConstructorStandingsRepository::class
 }

--- a/data/constructorstandings/src/prod/java/com/toquete/boxbox/data/constructorstandings/di/RemoteDataSourceKoinModule.kt
+++ b/data/constructorstandings/src/prod/java/com/toquete/boxbox/data/constructorstandings/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.constructorstandings.di
+
+import com.toquete.boxbox.data.constructorstandings.source.remote.ConstructorStandingsRemoteDataSource
+import com.toquete.boxbox.data.constructorstandings.source.remote.DefaultConstructorStandingsRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultConstructorStandingsRemoteDataSource) bind ConstructorStandingsRemoteDataSource::class
+}

--- a/data/countries/src/demo/java/com/toquete/boxbox/data/countries/di/RemoteDataSourceKoinModule.kt
+++ b/data/countries/src/demo/java/com/toquete/boxbox/data/countries/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.countries.di
+
+import com.toquete.boxbox.data.countries.source.remote.CountryRemoteDataSource
+import com.toquete.boxbox.data.countries.source.remote.DefaultCountryRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultCountryRemoteDataSource) bind CountryRemoteDataSource::class
+}

--- a/data/countries/src/main/java/com/toquete/boxbox/data/countries/di/CountriesKoinModule.kt
+++ b/data/countries/src/main/java/com/toquete/boxbox/data/countries/di/CountriesKoinModule.kt
@@ -1,14 +1,12 @@
 package com.toquete.boxbox.data.countries.di
 
 import com.toquete.boxbox.data.countries.repository.DefaultCountryRepository
-import com.toquete.boxbox.data.countries.source.remote.CountryRemoteDataSource
-import com.toquete.boxbox.data.countries.source.remote.DefaultCountryRemoteDataSource
 import com.toquete.boxbox.domain.repository.CountryRepository
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
-internal val countriesModule = module {
-    singleOf(::DefaultCountryRemoteDataSource) bind CountryRemoteDataSource::class
+val countriesModule = module {
+    includes(remoteDataSourceModule)
     singleOf(::DefaultCountryRepository) bind CountryRepository::class
 }

--- a/data/countries/src/prod/java/com/toquete/boxbox/data/countries/di/RemoteDataSourceKoinModule.kt
+++ b/data/countries/src/prod/java/com/toquete/boxbox/data/countries/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.countries.di
+
+import com.toquete.boxbox.data.countries.source.remote.CountryRemoteDataSource
+import com.toquete.boxbox.data.countries.source.remote.DefaultCountryRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultCountryRemoteDataSource) bind CountryRemoteDataSource::class
+}

--- a/data/driverimages/src/demo/java/com/toquete/boxbox/data/driverimages/di/RemoteDataSourceKoinModule.kt
+++ b/data/driverimages/src/demo/java/com/toquete/boxbox/data/driverimages/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.driverimages.di
+
+import com.toquete.boxbox.data.driverimages.source.remote.DefaultDriverImageRemoteDataSource
+import com.toquete.boxbox.data.driverimages.source.remote.DriverImageRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultDriverImageRemoteDataSource) bind DriverImageRemoteDataSource::class
+}

--- a/data/driverimages/src/main/java/com/toquete/boxbox/data/driverimages/di/DriverImagesKoinModule.kt
+++ b/data/driverimages/src/main/java/com/toquete/boxbox/data/driverimages/di/DriverImagesKoinModule.kt
@@ -1,14 +1,12 @@
 package com.toquete.boxbox.data.driverimages.di
 
 import com.toquete.boxbox.data.driverimages.repository.DefaultDriverImageRepository
-import com.toquete.boxbox.data.driverimages.source.remote.DefaultDriverImageRemoteDataSource
-import com.toquete.boxbox.data.driverimages.source.remote.DriverImageRemoteDataSource
 import com.toquete.boxbox.domain.repository.DriverImageRepository
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
-internal val driverImagesModule = module {
-    singleOf(::DefaultDriverImageRemoteDataSource) bind DriverImageRemoteDataSource::class
+val driverImagesModule = module {
+    includes(remoteDataSourceModule)
     singleOf(::DefaultDriverImageRepository) bind DriverImageRepository::class
 }

--- a/data/driverimages/src/prod/java/com/toquete/boxbox/data/driverimages/di/RemoteDataSourceKoinModule.kt
+++ b/data/driverimages/src/prod/java/com/toquete/boxbox/data/driverimages/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.driverimages.di
+
+import com.toquete.boxbox.data.driverimages.source.remote.DefaultDriverImageRemoteDataSource
+import com.toquete.boxbox.data.driverimages.source.remote.DriverImageRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultDriverImageRemoteDataSource) bind DriverImageRemoteDataSource::class
+}

--- a/data/driverstandings/src/demo/java/com/toquete/boxbox/data/driverstandings/di/RemoteDataSourceKoinModule.kt
+++ b/data/driverstandings/src/demo/java/com/toquete/boxbox/data/driverstandings/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.driverstandings.di
+
+import com.toquete.boxbox.data.driverstandings.source.remote.DefaultDriverStandingsRemoteDataSource
+import com.toquete.boxbox.data.driverstandings.source.remote.DriverStandingsRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultDriverStandingsRemoteDataSource) bind DriverStandingsRemoteDataSource::class
+}

--- a/data/driverstandings/src/main/java/com/toquete/boxbox/data/driverstandings/di/DriverStandingsKoinModule.kt
+++ b/data/driverstandings/src/main/java/com/toquete/boxbox/data/driverstandings/di/DriverStandingsKoinModule.kt
@@ -1,14 +1,12 @@
 package com.toquete.boxbox.data.driverstandings.di
 
 import com.toquete.boxbox.data.driverstandings.repository.DefaultDriverStandingsRepository
-import com.toquete.boxbox.data.driverstandings.source.remote.DefaultDriverStandingsRemoteDataSource
-import com.toquete.boxbox.data.driverstandings.source.remote.DriverStandingsRemoteDataSource
 import com.toquete.boxbox.domain.repository.DriverStandingsRepository
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
-internal val driverStandingsModule = module {
-    singleOf(::DefaultDriverStandingsRemoteDataSource) bind DriverStandingsRemoteDataSource::class
+val driverStandingsModule = module {
+    includes(remoteDataSourceModule)
     singleOf(::DefaultDriverStandingsRepository) bind DriverStandingsRepository::class
 }

--- a/data/driverstandings/src/prod/java/com/toquete/boxbox/data/driverstandings/di/RemoteDataSourceKoinModule.kt
+++ b/data/driverstandings/src/prod/java/com/toquete/boxbox/data/driverstandings/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.driverstandings.di
+
+import com.toquete.boxbox.data.driverstandings.source.remote.DefaultDriverStandingsRemoteDataSource
+import com.toquete.boxbox.data.driverstandings.source.remote.DriverStandingsRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultDriverStandingsRemoteDataSource) bind DriverStandingsRemoteDataSource::class
+}

--- a/data/raceresults/src/demo/java/com/toquete/boxbox/data/raceresults/di/RemoteDataSourceKoinModule.kt
+++ b/data/raceresults/src/demo/java/com/toquete/boxbox/data/raceresults/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.raceresults.di
+
+import com.toquete.boxbox.data.raceresults.source.remote.DefaultRaceResultRemoteDataSource
+import com.toquete.boxbox.data.raceresults.source.remote.RaceResultRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultRaceResultRemoteDataSource) bind RaceResultRemoteDataSource::class
+}

--- a/data/raceresults/src/main/java/com/toquete/boxbox/data/raceresults/di/RaceResultsKoinModule.kt
+++ b/data/raceresults/src/main/java/com/toquete/boxbox/data/raceresults/di/RaceResultsKoinModule.kt
@@ -1,14 +1,12 @@
 package com.toquete.boxbox.data.raceresults.di
 
 import com.toquete.boxbox.data.raceresults.repository.DefaultRaceResultRepository
-import com.toquete.boxbox.data.raceresults.source.remote.DefaultRaceResultRemoteDataSource
-import com.toquete.boxbox.data.raceresults.source.remote.RaceResultRemoteDataSource
 import com.toquete.boxbox.domain.repository.RaceResultRepository
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
-internal val raceResultsModule = module {
-    singleOf(::DefaultRaceResultRemoteDataSource) bind RaceResultRemoteDataSource::class
+val raceResultsModule = module {
+    includes(remoteDataSourceModule)
     singleOf(::DefaultRaceResultRepository) bind RaceResultRepository::class
 }

--- a/data/raceresults/src/prod/java/com/toquete/boxbox/data/raceresults/di/RemoteDataSourceKoinModule.kt
+++ b/data/raceresults/src/prod/java/com/toquete/boxbox/data/raceresults/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.raceresults.di
+
+import com.toquete.boxbox.data.raceresults.source.remote.DefaultRaceResultRemoteDataSource
+import com.toquete.boxbox.data.raceresults.source.remote.RaceResultRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultRaceResultRemoteDataSource) bind RaceResultRemoteDataSource::class
+}

--- a/data/races/src/demo/java/com/toquete/boxbox/data/races/di/RemoteDataSourceKoinModule.kt
+++ b/data/races/src/demo/java/com/toquete/boxbox/data/races/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.races.di
+
+import com.toquete.boxbox.data.races.source.remote.DefaultRaceRemoteDataSource
+import com.toquete.boxbox.data.races.source.remote.RaceRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultRaceRemoteDataSource) bind RaceRemoteDataSource::class
+}

--- a/data/races/src/main/java/com/toquete/boxbox/data/races/di/RacesKoinModule.kt
+++ b/data/races/src/main/java/com/toquete/boxbox/data/races/di/RacesKoinModule.kt
@@ -1,14 +1,12 @@
 package com.toquete.boxbox.data.races.di
 
 import com.toquete.boxbox.data.races.repository.DefaultRaceRepository
-import com.toquete.boxbox.data.races.source.remote.DefaultRaceRemoteDataSource
-import com.toquete.boxbox.data.races.source.remote.RaceRemoteDataSource
 import com.toquete.boxbox.domain.repository.RaceRepository
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
-internal val racesModule = module {
-    singleOf(::DefaultRaceRemoteDataSource) bind RaceRemoteDataSource::class
+val racesModule = module {
+    includes(remoteDataSourceModule)
     singleOf(::DefaultRaceRepository) bind RaceRepository::class
 }

--- a/data/races/src/prod/java/com/toquete/boxbox/data/races/di/RemoteDataSourceKoinModule.kt
+++ b/data/races/src/prod/java/com/toquete/boxbox/data/races/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.races.di
+
+import com.toquete.boxbox.data.races.source.remote.DefaultRaceRemoteDataSource
+import com.toquete.boxbox.data.races.source.remote.RaceRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultRaceRemoteDataSource) bind RaceRemoteDataSource::class
+}

--- a/data/sprintresults/src/demo/java/com/toquete/boxbox/data/sprintresults/di/RemoteDataSourceKoinModule.kt
+++ b/data/sprintresults/src/demo/java/com/toquete/boxbox/data/sprintresults/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.sprintresults.di
+
+import com.toquete.boxbox.data.sprintresults.source.remote.DefaultSprintResultRemoteDataSource
+import com.toquete.boxbox.data.sprintresults.source.remote.SprintResultRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultSprintResultRemoteDataSource) bind SprintResultRemoteDataSource::class
+}

--- a/data/sprintresults/src/main/java/com/toquete/boxbox/data/sprintresults/di/SprintResultsKoinModule.kt
+++ b/data/sprintresults/src/main/java/com/toquete/boxbox/data/sprintresults/di/SprintResultsKoinModule.kt
@@ -1,14 +1,12 @@
 package com.toquete.boxbox.data.sprintresults.di
 
 import com.toquete.boxbox.data.sprintresults.repository.DefaultSprintResultRepository
-import com.toquete.boxbox.data.sprintresults.source.remote.DefaultSprintResultRemoteDataSource
-import com.toquete.boxbox.data.sprintresults.source.remote.SprintResultRemoteDataSource
 import com.toquete.boxbox.domain.repository.SprintResultRepository
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
-internal val sprintResultsModule = module {
-    singleOf(::DefaultSprintResultRemoteDataSource) bind SprintResultRemoteDataSource::class
+val sprintResultsModule = module {
+    includes(remoteDataSourceModule)
     singleOf(::DefaultSprintResultRepository) bind SprintResultRepository::class
 }

--- a/data/sprintresults/src/prod/java/com/toquete/boxbox/data/sprintresults/di/RemoteDataSourceKoinModule.kt
+++ b/data/sprintresults/src/prod/java/com/toquete/boxbox/data/sprintresults/di/RemoteDataSourceKoinModule.kt
@@ -1,0 +1,11 @@
+package com.toquete.boxbox.data.sprintresults.di
+
+import com.toquete.boxbox.data.sprintresults.source.remote.DefaultSprintResultRemoteDataSource
+import com.toquete.boxbox.data.sprintresults.source.remote.SprintResultRemoteDataSource
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal val remoteDataSourceModule = module {
+    singleOf(::DefaultSprintResultRemoteDataSource) bind SprintResultRemoteDataSource::class
+}

--- a/feature/raceresults/src/main/java/com/toquete/boxbox/feature/raceresults/di/RaceResultsFeatureKoinModule.kt
+++ b/feature/raceresults/src/main/java/com/toquete/boxbox/feature/raceresults/di/RaceResultsFeatureKoinModule.kt
@@ -4,6 +4,6 @@ import com.toquete.boxbox.feature.raceresults.ui.RaceResultsViewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
-internal val raceResultsFeatureModule = module {
+val raceResultsFeatureModule = module {
     viewModelOf(::RaceResultsViewModel)
 }

--- a/feature/raceresults/src/main/java/com/toquete/boxbox/feature/raceresults/ui/RaceResultScreen.kt
+++ b/feature/raceresults/src/main/java/com/toquete/boxbox/feature/raceresults/ui/RaceResultScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.toquete.boxbox.core.model.Constructor
 import com.toquete.boxbox.core.model.Driver
@@ -31,11 +30,12 @@ import com.toquete.boxbox.core.ui.annotation.UiModePreviews
 import com.toquete.boxbox.core.ui.theme.BoxBoxTheme
 import com.toquete.boxbox.core.ui.theme.FormulaOne
 import com.toquete.boxbox.feature.raceresults.R
+import org.koin.androidx.compose.koinViewModel
 
 @Composable
 internal fun RaceResultRoute(
     onNavigateUp: () -> Unit,
-    viewModel: RaceResultsViewModel = hiltViewModel()
+    viewModel: RaceResultsViewModel = koinViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     RaceResultScreen(state, onNavigateUp)

--- a/feature/raceresults/src/main/java/com/toquete/boxbox/feature/raceresults/ui/RaceResultsViewModel.kt
+++ b/feature/raceresults/src/main/java/com/toquete/boxbox/feature/raceresults/ui/RaceResultsViewModel.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 
-internal class RaceResultsViewModel constructor(
+internal class RaceResultsViewModel(
     savedStateHandle: SavedStateHandle,
     getCurrentSeasonRaceResultsUseCase: GetCurrentSeasonRaceResultsUseCase,
     getCurrentSprintResultsUseCase: GetCurrentSeasonSprintResultsUseCase

--- a/feature/raceresults/src/main/java/com/toquete/boxbox/feature/raceresults/ui/RaceResultsViewModel.kt
+++ b/feature/raceresults/src/main/java/com/toquete/boxbox/feature/raceresults/ui/RaceResultsViewModel.kt
@@ -7,14 +7,11 @@ import androidx.navigation.toRoute
 import com.toquete.boxbox.core.navigation.BoxBoxRoute
 import com.toquete.boxbox.domain.usecase.GetCurrentSeasonRaceResultsUseCase
 import com.toquete.boxbox.domain.usecase.GetCurrentSeasonSprintResultsUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
-import javax.inject.Inject
 
-@HiltViewModel
-internal class RaceResultsViewModel @Inject constructor(
+internal class RaceResultsViewModel constructor(
     savedStateHandle: SavedStateHandle,
     getCurrentSeasonRaceResultsUseCase: GetCurrentSeasonRaceResultsUseCase,
     getCurrentSprintResultsUseCase: GetCurrentSeasonSprintResultsUseCase

--- a/feature/races/src/main/java/com/toquete/boxbox/feature/races/di/RacesFeatureKoinModule.kt
+++ b/feature/races/src/main/java/com/toquete/boxbox/feature/races/di/RacesFeatureKoinModule.kt
@@ -4,6 +4,6 @@ import com.toquete.boxbox.feature.races.ui.RacesViewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
-internal val racesFeatureModule = module {
+val racesFeatureModule = module {
     viewModelOf(::RacesViewModel)
 }

--- a/feature/races/src/main/java/com/toquete/boxbox/feature/races/ui/RacesScreen.kt
+++ b/feature/races/src/main/java/com/toquete/boxbox/feature/races/ui/RacesScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.toquete.boxbox.core.model.Circuit
 import com.toquete.boxbox.core.model.Location
@@ -38,12 +37,13 @@ import com.toquete.boxbox.core.ui.annotation.UiModePreviews
 import com.toquete.boxbox.core.ui.theme.BoxBoxTheme
 import com.toquete.boxbox.feature.races.model.RacesTab
 import kotlinx.coroutines.launch
+import org.koin.androidx.compose.koinViewModel
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 @Composable
 internal fun RacesRoute(
-    viewModel: RacesViewModel = hiltViewModel(),
+    viewModel: RacesViewModel = koinViewModel(),
     onRaceClick: (Int, String) -> Unit = { _, _ -> }
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()

--- a/feature/races/src/main/java/com/toquete/boxbox/feature/races/ui/RacesViewModel.kt
+++ b/feature/races/src/main/java/com/toquete/boxbox/feature/races/ui/RacesViewModel.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 
-internal class RacesViewModel constructor(
+internal class RacesViewModel(
     getUpcomingRacesUseCase: GetUpcomingRacesInCurrentSeasonUseCase,
     getPastRacesUseCase: GetPastRacesInCurrentSeasonUseCase
 ) : ViewModel() {

--- a/feature/races/src/main/java/com/toquete/boxbox/feature/races/ui/RacesViewModel.kt
+++ b/feature/races/src/main/java/com/toquete/boxbox/feature/races/ui/RacesViewModel.kt
@@ -4,14 +4,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.toquete.boxbox.domain.usecase.GetPastRacesInCurrentSeasonUseCase
 import com.toquete.boxbox.domain.usecase.GetUpcomingRacesInCurrentSeasonUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
-import javax.inject.Inject
 
-@HiltViewModel
-internal class RacesViewModel @Inject constructor(
+internal class RacesViewModel constructor(
     getUpcomingRacesUseCase: GetUpcomingRacesInCurrentSeasonUseCase,
     getPastRacesUseCase: GetPastRacesInCurrentSeasonUseCase
 ) : ViewModel() {

--- a/feature/settings/src/main/java/com/toquete/boxbox/feature/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/toquete/boxbox/feature/settings/ui/SettingsScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.toquete.boxbox.core.model.ColorConfig
 import com.toquete.boxbox.core.model.DarkThemeConfig
@@ -33,10 +32,11 @@ import com.toquete.boxbox.core.ui.annotation.UiModePreviews
 import com.toquete.boxbox.core.ui.theme.BoxBoxTheme
 import com.toquete.boxbox.core.ui.theme.supportsDynamicTheming
 import com.toquete.boxbox.feature.settings.R
+import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun SettingsScreen(
-    viewModel: SettingsViewModel = hiltViewModel(),
+    viewModel: SettingsViewModel = koinViewModel(),
     onDismiss: () -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()

--- a/feature/settings/src/main/java/com/toquete/boxbox/feature/settings/ui/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/toquete/boxbox/feature/settings/ui/SettingsViewModel.kt
@@ -17,7 +17,7 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 @OptIn(ExperimentalTime::class)
-class SettingsViewModel constructor(
+class SettingsViewModel(
     private val preferencesRepository: UserPreferencesRepository,
     private val timeZone: TimeZone
 ) : ViewModel() {

--- a/feature/settings/src/main/java/com/toquete/boxbox/feature/settings/ui/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/toquete/boxbox/feature/settings/ui/SettingsViewModel.kt
@@ -3,7 +3,6 @@ package com.toquete.boxbox.feature.settings.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.toquete.boxbox.domain.repository.UserPreferencesRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -14,13 +13,11 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.format
 import kotlinx.datetime.format.char
 import kotlinx.datetime.toLocalDateTime
-import javax.inject.Inject
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 @OptIn(ExperimentalTime::class)
-@HiltViewModel
-class SettingsViewModel @Inject constructor(
+class SettingsViewModel constructor(
     private val preferencesRepository: UserPreferencesRepository,
     private val timeZone: TimeZone
 ) : ViewModel() {

--- a/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/constructors/ConstructorStandingsScreen.kt
+++ b/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/constructors/ConstructorStandingsScreen.kt
@@ -14,16 +14,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.toquete.boxbox.core.model.Constructor
 import com.toquete.boxbox.core.model.ConstructorStanding
 import com.toquete.boxbox.core.ui.annotation.UiModePreviews
 import com.toquete.boxbox.core.ui.theme.BoxBoxTheme
+import org.koin.androidx.compose.koinViewModel
 
 @Composable
 internal fun ConstructorStandingsRoute(
-    viewModel: ConstructorStandingsViewModel = hiltViewModel()
+    viewModel: ConstructorStandingsViewModel = koinViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     ConstructorStandingsScreen(state)

--- a/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/constructors/ConstructorStandingsViewModel.kt
+++ b/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/constructors/ConstructorStandingsViewModel.kt
@@ -3,14 +3,11 @@ package com.toquete.boxbox.feature.standings.constructors
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.toquete.boxbox.domain.repository.ConstructorStandingsRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import javax.inject.Inject
 
-@HiltViewModel
-internal class ConstructorStandingsViewModel @Inject constructor(
+internal class ConstructorStandingsViewModel constructor(
     repository: ConstructorStandingsRepository
 ) : ViewModel() {
 

--- a/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/constructors/ConstructorStandingsViewModel.kt
+++ b/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/constructors/ConstructorStandingsViewModel.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
-internal class ConstructorStandingsViewModel constructor(
+internal class ConstructorStandingsViewModel(
     repository: ConstructorStandingsRepository
 ) : ViewModel() {
 

--- a/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/di/StandingsKoinModule.kt
+++ b/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/di/StandingsKoinModule.kt
@@ -5,7 +5,7 @@ import com.toquete.boxbox.feature.standings.drivers.DriverStandingsViewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
-internal val standingsModule = module {
+val standingsModule = module {
     viewModelOf(::DriverStandingsViewModel)
     viewModelOf(::ConstructorStandingsViewModel)
 }

--- a/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/drivers/DriverStandingsScreen.kt
+++ b/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/drivers/DriverStandingsScreen.kt
@@ -14,17 +14,17 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.toquete.boxbox.core.model.Constructor
 import com.toquete.boxbox.core.model.Driver
 import com.toquete.boxbox.core.model.DriverStanding
 import com.toquete.boxbox.core.ui.annotation.UiModePreviews
 import com.toquete.boxbox.core.ui.theme.BoxBoxTheme
+import org.koin.androidx.compose.koinViewModel
 
 @Composable
 internal fun DriverStandingsRoute(
-    viewModel: DriverStandingsViewModel = hiltViewModel()
+    viewModel: DriverStandingsViewModel = koinViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     DriverStandingsScreen(state)

--- a/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/drivers/DriverStandingsViewModel.kt
+++ b/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/drivers/DriverStandingsViewModel.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
-internal class DriverStandingsViewModel constructor(
+internal class DriverStandingsViewModel(
     repository: DriverStandingsRepository
 ) : ViewModel() {
 

--- a/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/drivers/DriverStandingsViewModel.kt
+++ b/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/drivers/DriverStandingsViewModel.kt
@@ -3,14 +3,11 @@ package com.toquete.boxbox.feature.standings.drivers
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.toquete.boxbox.domain.repository.DriverStandingsRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import javax.inject.Inject
 
-@HiltViewModel
-internal class DriverStandingsViewModel @Inject constructor(
+internal class DriverStandingsViewModel constructor(
     repository: DriverStandingsRepository
 ) : ViewModel() {
 


### PR DESCRIPTION
## Summary
- Add build-type Koin modules for `AppCheckProviderFactory` and `Timber.Tree` (debug/minified: Debug variants; release: PlayIntegrity + Crashlytics)
- Replace `@HiltAndroidApp` / `Configuration.Provider` / `@Inject` fields with `startKoin { workManagerFactory() }` listing all modules
- Make `internal` Koin module vals `public` so `:app` can reference them across module boundaries
- Add `:core:common`, `:core:network`, `:core:database` as direct `:app` dependencies

## Test plan
- [ ] `./gradlew assembleProdDebug` passes
- [ ] `./gradlew testProdDebugUnitTest` passes
- [ ] `./gradlew detekt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)