### PR TITLE
chore: remove Hilt leftovers from plugins and add kotlinx-collections-immutable

### DIFF
--- a/app/src/main/java/com/toquete/boxbox/util/monitor/ConnectivityManagerNetworkMonitor.kt
+++ b/app/src/main/java/com/toquete/boxbox/util/monitor/ConnectivityManagerNetworkMonitor.kt
@@ -7,14 +7,13 @@ import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import androidx.core.content.getSystemService
 import com.toquete.boxbox.core.common.util.NetworkMonitor
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.conflate
 
 class ConnectivityManagerNetworkMonitor(
-    @ApplicationContext private val context: Context
+    private val context: Context
 ) : NetworkMonitor {
 
     override val isOnline: Flow<Boolean> = callbackFlow {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ junit-ext = "1.3.0"
 espresso = "3.7.0"
 desugar-jdk-libs = "2.1.5"
 koltinx-datetime = "0.7.0"
+kotlinx-collections-immutable = "0.4.0"
 room = "2.8.4"
 splashscreen = "1.2.0"
 work = "2.11.2"
@@ -100,6 +101,7 @@ compose-ui-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore-preferences"}
 desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugar-jdk-libs" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "koltinx-datetime" }
+kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }

--- a/plugins/src/main/java/AndroidFeatureConventionPlugin.kt
+++ b/plugins/src/main/java/AndroidFeatureConventionPlugin.kt
@@ -12,7 +12,6 @@ class AndroidFeatureConventionPlugin : Plugin<Project> {
         with(target) {
             with(pluginManager) {
                 apply("boxbox.android.library")
-                apply("boxbox.android.hilt")
             }
 
             extensions.configure<LibraryExtension> {
@@ -23,6 +22,7 @@ class AndroidFeatureConventionPlugin : Plugin<Project> {
             dependencies {
                 add("implementation", libs.findLibrary("core.ktx").get())
                 add("implementation", libs.findBundle("coil").get())
+                add("implementation", libs.findLibrary("kotlinx.collections.immutable").get())
             }
         }
     }

--- a/plugins/src/main/java/com/toquete/boxbox/plugins/AndroidCompose.kt
+++ b/plugins/src/main/java/com/toquete/boxbox/plugins/AndroidCompose.kt
@@ -23,7 +23,6 @@ internal fun Project.configureAndroidCompose(
             add("implementation", libs.findBundle("lifecycle").get())
             add("implementation", libs.findBundle("compose").get())
             add("implementation", libs.findLibrary("compose.navigation").get())
-            add("implementation", libs.findLibrary("hilt.navigation").get())
             add("implementation", libs.findLibrary("compose.material3").get())
             add("implementation", libs.findLibrary("compose.preview").get())
             add("implementation", libs.findLibrary("compose.material.icons").get())


### PR DESCRIPTION
## Summary

- Remove `boxbox.android.hilt` plugin from `AndroidFeatureConventionPlugin` (feature modules no longer need Hilt wired automatically)
- Remove `hilt-navigation` dependency from `AndroidCompose` convention plugin
- Remove `@ApplicationContext` Hilt annotation from `ConnectivityManagerNetworkMonitor` constructor
- Add `kotlinx-collections-immutable 0.4.0` to the version catalog for use in feature modules

## Test plan

- [ ] `./gradlew assembleProdDebug`
- [ ] `./gradlew testProdDebugUnitTest`
- [ ] `./gradlew detekt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)