### PR TITLE
feat(feature): use ImmutableList in UI state classes

### DIFF
--- a/feature/raceresults/src/main/java/com/toquete/boxbox/feature/raceresults/ui/RaceResultScreen.kt
+++ b/feature/raceresults/src/main/java/com/toquete/boxbox/feature/raceresults/ui/RaceResultScreen.kt
@@ -30,6 +30,7 @@ import com.toquete.boxbox.core.ui.annotation.UiModePreviews
 import com.toquete.boxbox.core.ui.theme.BoxBoxTheme
 import com.toquete.boxbox.core.ui.theme.FormulaOne
 import com.toquete.boxbox.feature.raceresults.R
+import kotlinx.collections.immutable.persistentListOf
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -109,7 +110,7 @@ internal fun RaceResultPreview() {
             RaceResultScreen(
                 state = RaceResultsState(
                     raceName = "Bahrain",
-                    results = listOf(
+                    results = persistentListOf(
                         RaceResult(
                             season = "2021",
                             round = 1,
@@ -163,7 +164,7 @@ internal fun EmptyStatePreview() {
             RaceResultScreen(
                 state = RaceResultsState(
                     raceName = "Bahrain",
-                    results = emptyList()
+                    results = persistentListOf()
                 )
             )
         }

--- a/feature/raceresults/src/main/java/com/toquete/boxbox/feature/raceresults/ui/RaceResultsState.kt
+++ b/feature/raceresults/src/main/java/com/toquete/boxbox/feature/raceresults/ui/RaceResultsState.kt
@@ -1,9 +1,11 @@
 package com.toquete.boxbox.feature.raceresults.ui
 
 import com.toquete.boxbox.core.model.RaceResult
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 internal data class RaceResultsState(
     val raceName: String = "",
-    val results: List<RaceResult> = emptyList(),
-    val sprintResults: List<RaceResult> = emptyList()
+    val results: ImmutableList<RaceResult> = persistentListOf(),
+    val sprintResults: ImmutableList<RaceResult> = persistentListOf()
 )

--- a/feature/raceresults/src/main/java/com/toquete/boxbox/feature/raceresults/ui/RaceResultsViewModel.kt
+++ b/feature/raceresults/src/main/java/com/toquete/boxbox/feature/raceresults/ui/RaceResultsViewModel.kt
@@ -7,6 +7,7 @@ import androidx.navigation.toRoute
 import com.toquete.boxbox.core.navigation.BoxBoxRoute
 import com.toquete.boxbox.domain.usecase.GetCurrentSeasonRaceResultsUseCase
 import com.toquete.boxbox.domain.usecase.GetCurrentSeasonSprintResultsUseCase
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
@@ -23,7 +24,7 @@ internal class RaceResultsViewModel(
         getCurrentSeasonRaceResultsUseCase(route.round),
         getCurrentSprintResultsUseCase(route.round)
     ) { raceResults, sprintResults ->
-        RaceResultsState(route.race, raceResults, sprintResults)
+        RaceResultsState(route.race, raceResults.toImmutableList(), sprintResults.toImmutableList())
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),

--- a/feature/raceresults/src/test/java/com/toquete/boxbox/feature/raceresults/ui/RaceResultScreenTest.kt
+++ b/feature/raceresults/src/test/java/com/toquete/boxbox/feature/raceresults/ui/RaceResultScreenTest.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.toquete.boxbox.core.testing.data.raceResults
 import com.toquete.boxbox.core.ui.theme.BoxBoxTheme
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -25,7 +27,7 @@ class RaceResultScreenTest {
                     RaceResultScreen(
                         state = RaceResultsState(
                             raceName = "Bahrain",
-                            results = raceResults
+                            results = raceResults.toImmutableList()
                         )
                     )
                 }
@@ -46,7 +48,7 @@ class RaceResultScreenTest {
                     RaceResultScreen(
                         state = RaceResultsState(
                             raceName = "Bahrain",
-                            results = emptyList()
+                            results = persistentListOf()
                         )
                     )
                 }

--- a/feature/raceresults/src/test/java/com/toquete/boxbox/feature/raceresults/ui/RaceResultsViewModelTest.kt
+++ b/feature/raceresults/src/test/java/com/toquete/boxbox/feature/raceresults/ui/RaceResultsViewModelTest.kt
@@ -12,6 +12,7 @@ import com.toquete.boxbox.domain.usecase.GetCurrentSeasonRaceResultsUseCase
 import com.toquete.boxbox.domain.usecase.GetCurrentSeasonSprintResultsUseCase
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collect
@@ -52,7 +53,7 @@ class RaceResultsViewModelTest {
 
         raceResultsFlow.emit(raceResults)
         sprintResultsFlow.emit(sprintRaceResults)
-        assertEquals(RaceResultsState(raceName = "Bahrain", raceResults, sprintRaceResults), viewModel.state.value)
+        assertEquals(RaceResultsState(raceName = "Bahrain", raceResults.toImmutableList(), sprintRaceResults.toImmutableList()), viewModel.state.value)
 
         backgroundScope.cancel()
     }

--- a/feature/races/src/main/java/com/toquete/boxbox/feature/races/ui/RacesScreen.kt
+++ b/feature/races/src/main/java/com/toquete/boxbox/feature/races/ui/RacesScreen.kt
@@ -36,6 +36,7 @@ import com.toquete.boxbox.core.model.Race
 import com.toquete.boxbox.core.ui.annotation.UiModePreviews
 import com.toquete.boxbox.core.ui.theme.BoxBoxTheme
 import com.toquete.boxbox.feature.races.model.RacesTab
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import kotlin.time.ExperimentalTime
@@ -123,7 +124,7 @@ internal fun RacesContentPreview() {
         Surface(color = MaterialTheme.colorScheme.background) {
             RacesScreen(
                 state = RacesState(
-                    upcomingRaces = listOf(
+                    upcomingRaces = persistentListOf(
                         Race(
                             season = "2023",
                             round = 1,

--- a/feature/races/src/main/java/com/toquete/boxbox/feature/races/ui/RacesState.kt
+++ b/feature/races/src/main/java/com/toquete/boxbox/feature/races/ui/RacesState.kt
@@ -1,8 +1,10 @@
 package com.toquete.boxbox.feature.races.ui
 
 import com.toquete.boxbox.core.model.Race
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 internal data class RacesState(
-    val upcomingRaces: List<Race> = emptyList(),
-    val pastRaces: List<Race> = emptyList()
+    val upcomingRaces: ImmutableList<Race> = persistentListOf(),
+    val pastRaces: ImmutableList<Race> = persistentListOf()
 )

--- a/feature/races/src/main/java/com/toquete/boxbox/feature/races/ui/RacesViewModel.kt
+++ b/feature/races/src/main/java/com/toquete/boxbox/feature/races/ui/RacesViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.toquete.boxbox.domain.usecase.GetPastRacesInCurrentSeasonUseCase
 import com.toquete.boxbox.domain.usecase.GetUpcomingRacesInCurrentSeasonUseCase
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
@@ -18,8 +19,8 @@ internal class RacesViewModel(
         getPastRacesUseCase()
     ) { upcomingRaces, pastRaces ->
         RacesState(
-            upcomingRaces,
-            pastRaces
+            upcomingRaces.toImmutableList(),
+            pastRaces.toImmutableList()
         )
     }.stateIn(
         scope = viewModelScope,

--- a/feature/races/src/test/java/com/toquete/boxbox/feature/races/ui/RacesViewModelTest.kt
+++ b/feature/races/src/test/java/com/toquete/boxbox/feature/races/ui/RacesViewModelTest.kt
@@ -7,6 +7,7 @@ import com.toquete.boxbox.domain.usecase.GetPastRacesInCurrentSeasonUseCase
 import com.toquete.boxbox.domain.usecase.GetUpcomingRacesInCurrentSeasonUseCase
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collect
@@ -44,7 +45,7 @@ class RacesViewModelTest {
 
         upcomingRacesFlow.emit(races)
         pastRacesFlow.emit(races)
-        assertEquals(RacesState(races, races), viewModel.state.value)
+        assertEquals(RacesState(races.toImmutableList(), races.toImmutableList()), viewModel.state.value)
 
         backgroundScope.cancel()
     }

--- a/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/constructors/ConstructorStandingsScreen.kt
+++ b/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/constructors/ConstructorStandingsScreen.kt
@@ -19,6 +19,7 @@ import com.toquete.boxbox.core.model.Constructor
 import com.toquete.boxbox.core.model.ConstructorStanding
 import com.toquete.boxbox.core.ui.annotation.UiModePreviews
 import com.toquete.boxbox.core.ui.theme.BoxBoxTheme
+import kotlinx.collections.immutable.persistentListOf
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -55,7 +56,7 @@ internal fun FullConstructorStandingsScreenPreview() {
         Surface(color = MaterialTheme.colorScheme.background) {
             ConstructorStandingsScreen(
                 state = ConstructorStandingsState(
-                    standings = listOf(
+                    standings = persistentListOf(
                         ConstructorStanding(
                             position = 1,
                             points = "258",

--- a/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/constructors/ConstructorStandingsState.kt
+++ b/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/constructors/ConstructorStandingsState.kt
@@ -1,7 +1,9 @@
 package com.toquete.boxbox.feature.standings.constructors
 
 import com.toquete.boxbox.core.model.ConstructorStanding
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 internal data class ConstructorStandingsState(
-    val standings: List<ConstructorStanding> = emptyList()
+    val standings: ImmutableList<ConstructorStanding> = persistentListOf()
 )

--- a/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/constructors/ConstructorStandingsViewModel.kt
+++ b/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/constructors/ConstructorStandingsViewModel.kt
@@ -3,6 +3,7 @@ package com.toquete.boxbox.feature.standings.constructors
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.toquete.boxbox.domain.repository.ConstructorStandingsRepository
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -12,7 +13,7 @@ internal class ConstructorStandingsViewModel(
 ) : ViewModel() {
 
     val state = repository.getConstructorStandings()
-        .map { ConstructorStandingsState(it) }
+        .map { ConstructorStandingsState(it.toImmutableList()) }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),

--- a/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/drivers/DriverStandingsScreen.kt
+++ b/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/drivers/DriverStandingsScreen.kt
@@ -20,6 +20,7 @@ import com.toquete.boxbox.core.model.Driver
 import com.toquete.boxbox.core.model.DriverStanding
 import com.toquete.boxbox.core.ui.annotation.UiModePreviews
 import com.toquete.boxbox.core.ui.theme.BoxBoxTheme
+import kotlinx.collections.immutable.persistentListOf
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -56,7 +57,7 @@ internal fun FullDriverStandingsScreenPreview() {
         Surface(color = MaterialTheme.colorScheme.background) {
             DriverStandingsScreen(
                 state = DriverStandingsState(
-                    standings = listOf(
+                    standings = persistentListOf(
                         DriverStanding(
                             position = 1,
                             points = "258",

--- a/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/drivers/DriverStandingsState.kt
+++ b/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/drivers/DriverStandingsState.kt
@@ -1,7 +1,9 @@
 package com.toquete.boxbox.feature.standings.drivers
 
 import com.toquete.boxbox.core.model.DriverStanding
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 internal data class DriverStandingsState(
-    val standings: List<DriverStanding> = emptyList()
+    val standings: ImmutableList<DriverStanding> = persistentListOf()
 )

--- a/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/drivers/DriverStandingsViewModel.kt
+++ b/feature/standings/src/main/java/com/toquete/boxbox/feature/standings/drivers/DriverStandingsViewModel.kt
@@ -3,6 +3,7 @@ package com.toquete.boxbox.feature.standings.drivers
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.toquete.boxbox.domain.repository.DriverStandingsRepository
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -12,7 +13,7 @@ internal class DriverStandingsViewModel(
 ) : ViewModel() {
 
     val state = repository.getDriverStandings()
-        .map { DriverStandingsState(it) }
+        .map { DriverStandingsState(it.toImmutableList()) }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),

--- a/feature/standings/src/test/java/com/toquete/boxbox/feature/standings/constructors/ConstructorStandingsViewModelTest.kt
+++ b/feature/standings/src/test/java/com/toquete/boxbox/feature/standings/constructors/ConstructorStandingsViewModelTest.kt
@@ -6,6 +6,7 @@ import com.toquete.boxbox.core.testing.util.MainDispatcherRule
 import com.toquete.boxbox.domain.repository.ConstructorStandingsRepository
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collect
@@ -39,7 +40,7 @@ class ConstructorStandingsViewModelTest {
         assertEquals(ConstructorStandingsState(), viewModel.state.value)
 
         constructorsFlow.emit(constructorStandings)
-        assertEquals(ConstructorStandingsState(constructorStandings), viewModel.state.value)
+        assertEquals(ConstructorStandingsState(constructorStandings.toImmutableList()), viewModel.state.value)
 
         backgroundScope.cancel()
     }

--- a/feature/standings/src/test/java/com/toquete/boxbox/feature/standings/drivers/DriverStandingsViewModelTest.kt
+++ b/feature/standings/src/test/java/com/toquete/boxbox/feature/standings/drivers/DriverStandingsViewModelTest.kt
@@ -6,6 +6,7 @@ import com.toquete.boxbox.core.testing.util.MainDispatcherRule
 import com.toquete.boxbox.domain.repository.DriverStandingsRepository
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collect
@@ -39,7 +40,7 @@ class DriverStandingsViewModelTest {
         assertEquals(DriverStandingsState(), viewModel.state.value)
 
         driversFlow.emit(driverStandings)
-        assertEquals(DriverStandingsState(driverStandings), viewModel.state.value)
+        assertEquals(DriverStandingsState(driverStandings.toImmutableList()), viewModel.state.value)
 
         backgroundScope.cancel()
     }


### PR DESCRIPTION
## Summary

- Replaces `List` with `ImmutableList` (from `kotlinx-collections-immutable`) in all four feature UI state classes: `DriverStandingsState`, `ConstructorStandingsState`, `RacesState`, and `RaceResultsState`
- Adds `toImmutableList()` in each ViewModel at the mapping site, so lists from repositories/use cases are wrapped before entering the state
- Updates previews and tests to use `persistentListOf()`/`toImmutableList()` consistently

## Test plan

- [ ] `./gradlew :feature:standings:testProdDebugUnitTest` — passes
- [ ] `./gradlew :feature:races:testProdDebugUnitTest` — passes
- [ ] `./gradlew :feature:raceresults:testProdDebugUnitTest` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)